### PR TITLE
Enhance files attachment validation and handling in Copilot SDK

### DIFF
--- a/src/Lumi/Services/AttachmentPreparationService.cs
+++ b/src/Lumi/Services/AttachmentPreparationService.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using GitHub.Copilot.SDK;
+
+namespace Lumi.Services;
+
+internal sealed record AttachmentPreparationResult(
+    List<UserMessageAttachment> Attachments,
+    string? ErrorMessage)
+{
+    public bool Success => ErrorMessage is null;
+}
+
+internal static class AttachmentPreparationService
+{
+    private const string DocxExtension = ".docx";
+    private static readonly byte[] OleCompoundFileMagic = [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1];
+
+    public static AttachmentPreparationResult PrepareForCopilot(IEnumerable<string> paths)
+    {
+        ArgumentNullException.ThrowIfNull(paths);
+
+        var attachments = new List<UserMessageAttachment>();
+        foreach (var path in paths.Where(static p => !string.IsNullOrWhiteSpace(p)))
+        {
+            var result = PrepareOne(path);
+            if (!result.Success)
+                return new AttachmentPreparationResult([], result.ErrorMessage);
+
+            attachments.Add(result.Attachment);
+        }
+
+        return new AttachmentPreparationResult(attachments, null);
+    }
+
+    public static string? ValidatePendingPath(string path)
+        => PrepareOne(path).ErrorMessage;
+
+    private static SingleAttachmentPreparationResult PrepareOne(string path)
+    {
+        string fullPath;
+        try
+        {
+            fullPath = Path.GetFullPath(path);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return SingleAttachmentPreparationResult.Fail($"Invalid attachment path \"{path}\": {ex.Message}");
+        }
+
+        if (Directory.Exists(fullPath))
+        {
+            return SingleAttachmentPreparationResult.Ok(new UserMessageAttachmentDirectory
+            {
+                Path = fullPath,
+                DisplayName = new DirectoryInfo(fullPath).Name
+            });
+        }
+
+        if (!File.Exists(fullPath))
+            return SingleAttachmentPreparationResult.Fail($"Attachment not found: {path}");
+
+        var docxValidationError = ValidateDocxIfNeeded(fullPath);
+        if (docxValidationError is not null)
+            return SingleAttachmentPreparationResult.Fail(docxValidationError);
+
+        return SingleAttachmentPreparationResult.Ok(new UserMessageAttachmentFile
+        {
+            Path = fullPath,
+            DisplayName = Path.GetFileName(fullPath)
+        });
+    }
+
+    private static string? ValidateDocxIfNeeded(string path)
+    {
+        if (!string.Equals(Path.GetExtension(path), DocxExtension, StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        byte[] header;
+        try
+        {
+            using var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            header = new byte[Math.Min(8, (int)Math.Min(stream.Length, 8))];
+            _ = stream.Read(header, 0, header.Length);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return $"Could not read attachment \"{Path.GetFileName(path)}\": {ex.Message}";
+        }
+
+        if (header.AsSpan().StartsWith(OleCompoundFileMagic))
+        {
+            return $"\"{Path.GetFileName(path)}\" has a .docx extension, but appears to be an older or encrypted Word/OLE document. Re-save it as a modern .docx file and attach it again.";
+        }
+
+        if (!LooksLikeZip(header))
+        {
+            return $"\"{Path.GetFileName(path)}\" has a .docx extension, but is not a valid modern Word document.";
+        }
+
+        try
+        {
+            using var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+            var hasContentTypes = archive.GetEntry("[Content_Types].xml") is not null;
+            var hasMainDocument = archive.GetEntry("word/document.xml") is not null;
+            if (!hasContentTypes || !hasMainDocument)
+                return $"\"{Path.GetFileName(path)}\" has a .docx extension, but is missing required Word document parts.";
+        }
+        catch (Exception ex) when (ex is InvalidDataException or IOException or UnauthorizedAccessException)
+        {
+            return $"Could not read \"{Path.GetFileName(path)}\" as a modern Word document: {ex.Message}";
+        }
+
+        return null;
+    }
+
+    private static bool LooksLikeZip(ReadOnlySpan<byte> header)
+    {
+        if (header.Length < 4)
+            return false;
+
+        return header[0] == 0x50
+               && header[1] == 0x4B
+               && ((header[2] == 0x03 && header[3] == 0x04)
+                   || (header[2] == 0x05 && header[3] == 0x06)
+                   || (header[2] == 0x07 && header[3] == 0x08));
+    }
+
+    private sealed record SingleAttachmentPreparationResult(
+        UserMessageAttachment Attachment,
+        string? ErrorMessage)
+    {
+        public bool Success => ErrorMessage is null;
+
+        public static SingleAttachmentPreparationResult Ok(UserMessageAttachment attachment)
+            => new(attachment, null);
+
+        public static SingleAttachmentPreparationResult Fail(string errorMessage)
+            => new(new UserMessageAttachment(), errorMessage);
+    }
+}

--- a/src/Lumi/Services/AttachmentPreparationService.cs
+++ b/src/Lumi/Services/AttachmentPreparationService.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using GitHub.Copilot.SDK;
 
@@ -16,9 +15,6 @@ internal sealed record AttachmentPreparationResult(
 
 internal static class AttachmentPreparationService
 {
-    private const string DocxExtension = ".docx";
-    private static readonly byte[] OleCompoundFileMagic = [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1];
-
     public static AttachmentPreparationResult PrepareForCopilot(IEnumerable<string> paths)
     {
         ArgumentNullException.ThrowIfNull(paths);
@@ -63,71 +59,11 @@ internal static class AttachmentPreparationService
         if (!File.Exists(fullPath))
             return SingleAttachmentPreparationResult.Fail($"Attachment not found: {path}");
 
-        var docxValidationError = ValidateDocxIfNeeded(fullPath);
-        if (docxValidationError is not null)
-            return SingleAttachmentPreparationResult.Fail(docxValidationError);
-
         return SingleAttachmentPreparationResult.Ok(new UserMessageAttachmentFile
         {
             Path = fullPath,
             DisplayName = Path.GetFileName(fullPath)
         });
-    }
-
-    private static string? ValidateDocxIfNeeded(string path)
-    {
-        if (!string.Equals(Path.GetExtension(path), DocxExtension, StringComparison.OrdinalIgnoreCase))
-            return null;
-
-        byte[] header;
-        try
-        {
-            using var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-            header = new byte[Math.Min(8, (int)Math.Min(stream.Length, 8))];
-            _ = stream.Read(header, 0, header.Length);
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-        {
-            return $"Could not read attachment \"{Path.GetFileName(path)}\": {ex.Message}";
-        }
-
-        if (header.AsSpan().StartsWith(OleCompoundFileMagic))
-        {
-            return $"\"{Path.GetFileName(path)}\" has a .docx extension, but appears to be an older or encrypted Word/OLE document. Re-save it as a modern .docx file and attach it again.";
-        }
-
-        if (!LooksLikeZip(header))
-        {
-            return $"\"{Path.GetFileName(path)}\" has a .docx extension, but is not a valid modern Word document.";
-        }
-
-        try
-        {
-            using var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-            using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
-            var hasContentTypes = archive.GetEntry("[Content_Types].xml") is not null;
-            var hasMainDocument = archive.GetEntry("word/document.xml") is not null;
-            if (!hasContentTypes || !hasMainDocument)
-                return $"\"{Path.GetFileName(path)}\" has a .docx extension, but is missing required Word document parts.";
-        }
-        catch (Exception ex) when (ex is InvalidDataException or IOException or UnauthorizedAccessException)
-        {
-            return $"Could not read \"{Path.GetFileName(path)}\" as a modern Word document: {ex.Message}";
-        }
-
-        return null;
-    }
-
-    private static bool LooksLikeZip(ReadOnlySpan<byte> header)
-    {
-        if (header.Length < 4)
-            return false;
-
-        return header[0] == 0x50
-               && header[1] == 0x4B
-               && ((header[2] == 0x03 && header[3] == 0x04)
-                   || (header[2] == 0x05 && header[3] == 0x06)
-                   || (header[2] == 0x07 && header[3] == 0x08));
     }
 
     private sealed record SingleAttachmentPreparationResult(

--- a/src/Lumi/ViewModels/ChatViewModel.ChatStateCleanup.cs
+++ b/src/Lumi/ViewModels/ChatViewModel.ChatStateCleanup.cs
@@ -12,18 +12,22 @@ public partial class ChatViewModel
            && (runtime.IsBusy || runtime.IsStreaming || runtime.HasPendingBackgroundWork
                || runtime.PendingSessionUserMessageCount > 0);
 
-    private void QueueBusySendPrompt(Guid chatId, string prompt)
+    private void QueueBusySendPrompt(Guid chatId, string prompt, IEnumerable<string>? attachmentPaths = null)
     {
         if (string.IsNullOrWhiteSpace(prompt))
             return;
 
-        _queuedBusySendPrompts[chatId] = prompt;
+        _queuedBusySendPrompts[chatId] = new QueuedBusySend(
+            prompt,
+            attachmentPaths?.Where(static path => !string.IsNullOrWhiteSpace(path)).ToList() ?? []);
     }
 
     private async Task DrainQueuedBusySendAsync(Guid chatId)
     {
-        if (!_queuedBusySendPrompts.Remove(chatId, out var prompt) || string.IsNullOrWhiteSpace(prompt))
+        if (!_queuedBusySendPrompts.Remove(chatId, out var queuedSend) || string.IsNullOrWhiteSpace(queuedSend.Prompt))
             return;
+
+        var prompt = queuedSend.Prompt;
 
         if (CurrentChat?.Id != chatId)
         {
@@ -33,11 +37,11 @@ public partial class ChatViewModel
 
         if (IsChatRuntimeActive(chatId))
         {
-            _queuedBusySendPrompts[chatId] = prompt;
+            _queuedBusySendPrompts[chatId] = queuedSend;
             return;
         }
 
-        await SendMessageCore(prompt, consumeComposerPrompt: false);
+        await SendMessageCore(prompt, consumeComposerPrompt: false, queuedSend.AttachmentPaths);
     }
 
     private void ReleaseChatCancellation(Guid chatId, bool cancel)

--- a/src/Lumi/ViewModels/ChatViewModel.ChatStateCleanup.cs
+++ b/src/Lumi/ViewModels/ChatViewModel.ChatStateCleanup.cs
@@ -31,7 +31,7 @@ public partial class ChatViewModel
 
         if (CurrentChat?.Id != chatId)
         {
-            _chatDrafts[chatId] = prompt;
+            SaveChatDraft(chatId, prompt, queuedSend.AttachmentPaths);
             return;
         }
 

--- a/src/Lumi/ViewModels/ChatViewModel.Context.cs
+++ b/src/Lumi/ViewModels/ChatViewModel.Context.cs
@@ -396,8 +396,17 @@ public partial class ChatViewModel
         if (PendingAttachments.Contains(filePath))
             return;
 
+        var validationError = AttachmentPreparationService.ValidatePendingPath(filePath);
         PendingAttachments.Add(filePath);
-        PendingAttachmentItems.Add(new FileAttachmentItem(filePath, isRemovable: true, removeAction: RemoveAttachment));
+        PendingAttachmentItems.Add(new FileAttachmentItem(
+            filePath,
+            isRemovable: true,
+            removeAction: RemoveAttachment,
+            status: validationError is null ? StrataAttachmentStatus.Completed : StrataAttachmentStatus.Failed,
+            errorMessage: validationError));
+
+        if (validationError is not null)
+            StatusText = validationError;
     }
 
     public void RemoveAttachment(string filePath)
@@ -482,21 +491,11 @@ public partial class ChatViewModel
         return Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
     }
 
-    private List<UserMessageAttachment>? TakePendingAttachments()
-    {
-        if (PendingAttachments.Count == 0) return null;
-        var items = PendingAttachments.Select(fp => (UserMessageAttachment)new UserMessageAttachmentFile
-        {
-            Path = fp,
-            DisplayName = Path.GetFileName(fp)
-        }).ToList();
-        PendingAttachments.Clear();
-        PendingAttachmentItems.Clear();
-        return items;
-    }
+    internal static AttachmentPreparationResult PrepareSdkAttachmentsForPaths(IEnumerable<string> paths)
+        => AttachmentPreparationService.PrepareForCopilot(paths);
 
     /// <summary>
-    /// Rebases file attachment paths from the original project directory to the worktree.
+    /// Rebases attachment paths from the original project directory to the worktree.
     /// Files tagged via # resolve against the project directory when the worktree hasn't
     /// been created yet (lazy creation). This fixes those paths before sending.
     /// </summary>
@@ -518,14 +517,29 @@ public partial class ChatViewModel
 
         for (var i = 0; i < attachments.Count; i++)
         {
-            if (attachments[i] is not UserMessageAttachmentFile file)
+            var path = attachments[i] switch
+            {
+                UserMessageAttachmentFile file => file.Path,
+                UserMessageAttachmentDirectory directory => directory.Path,
+                _ => null
+            };
+
+            if (path is null)
                 continue;
 
-            var path = file.Path;
             if (path.StartsWith(normalizedProjectDir, StringComparison.OrdinalIgnoreCase))
             {
                 var rebasedPath = normalizedWorktreePath + path[normalizedProjectDir.Length..];
-                file.Path = rebasedPath;
+                switch (attachments[i])
+                {
+                    case UserMessageAttachmentFile file:
+                        file.Path = rebasedPath;
+                        break;
+                    case UserMessageAttachmentDirectory directory:
+                        directory.Path = rebasedPath;
+                        break;
+                }
+
                 if (i < userMsg.Attachments.Count)
                     userMsg.Attachments[i] = rebasedPath;
             }

--- a/src/Lumi/ViewModels/ChatViewModel.Context.cs
+++ b/src/Lumi/ViewModels/ChatViewModel.Context.cs
@@ -393,11 +393,14 @@ public partial class ChatViewModel
 
     public void AddAttachment(string filePath)
     {
-        if (PendingAttachments.Contains(filePath))
+        if (PendingAttachmentItems.Any(item =>
+                string.Equals(item.FilePath, filePath, StringComparison.OrdinalIgnoreCase)))
             return;
 
         var validationError = AttachmentPreparationService.ValidatePendingPath(filePath);
-        PendingAttachments.Add(filePath);
+        if (validationError is null)
+            PendingAttachments.Add(filePath);
+
         PendingAttachmentItems.Add(new FileAttachmentItem(
             filePath,
             isRemovable: true,

--- a/src/Lumi/ViewModels/ChatViewModel.UiState.cs
+++ b/src/Lumi/ViewModels/ChatViewModel.UiState.cs
@@ -98,11 +98,13 @@ public partial class ChatViewModel
     public ObservableCollection<StrataComposerChip> AvailableProjectChips { get; } = [];
     [ObservableProperty] private IEnumerable<StrataComposerChip>? _availableFileSuggestions;
     public ObservableCollection<FileAttachmentItem> PendingAttachmentItems { get; } = [];
+    [ObservableProperty] private string _pendingAttachmentErrorText = "";
 
     public bool IsWelcomeVisible => CurrentChat is null;
     public bool IsChatVisible => CurrentChat is not null;
     public bool HasPendingAttachments => PendingAttachmentItems.Count > 0;
     public bool HasSendablePendingAttachments => PendingAttachments.Count > 0;
+    public bool HasPendingAttachmentError => !string.IsNullOrWhiteSpace(PendingAttachmentErrorText);
     public bool HasProjectBadge => !string.IsNullOrWhiteSpace(ProjectBadgeText);
     public bool HasAgentBadge => !string.IsNullOrWhiteSpace(AgentBadgeText);
     public bool HasHeaderSubtitle => HasProjectBadge || HasAgentBadge;
@@ -765,11 +767,24 @@ public partial class ChatViewModel
     private void OnPendingAttachmentItemsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         OnPropertyChanged(nameof(HasPendingAttachments));
+        UpdatePendingAttachmentErrorText();
     }
 
     private void OnPendingAttachmentsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         OnPropertyChanged(nameof(HasSendablePendingAttachments));
+    }
+
+    partial void OnPendingAttachmentErrorTextChanged(string value)
+    {
+        OnPropertyChanged(nameof(HasPendingAttachmentError));
+    }
+
+    private void UpdatePendingAttachmentErrorText()
+    {
+        PendingAttachmentErrorText = PendingAttachmentItems
+            .Select(static item => item.ErrorMessage)
+            .FirstOrDefault(static error => !string.IsNullOrWhiteSpace(error)) ?? "";
     }
 
     private void OnActiveSkillChipsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs args)

--- a/src/Lumi/ViewModels/ChatViewModel.UiState.cs
+++ b/src/Lumi/ViewModels/ChatViewModel.UiState.cs
@@ -102,6 +102,7 @@ public partial class ChatViewModel
     public bool IsWelcomeVisible => CurrentChat is null;
     public bool IsChatVisible => CurrentChat is not null;
     public bool HasPendingAttachments => PendingAttachmentItems.Count > 0;
+    public bool HasSendablePendingAttachments => PendingAttachments.Count > 0;
     public bool HasProjectBadge => !string.IsNullOrWhiteSpace(ProjectBadgeText);
     public bool HasAgentBadge => !string.IsNullOrWhiteSpace(AgentBadgeText);
     public bool HasHeaderSubtitle => HasProjectBadge || HasAgentBadge;
@@ -295,6 +296,7 @@ public partial class ChatViewModel
 
         ActiveSkillChips.CollectionChanged += OnActiveSkillChipsCollectionChanged;
         ActiveMcpChips.CollectionChanged += OnActiveMcpChipsCollectionChanged;
+        PendingAttachments.CollectionChanged += OnPendingAttachmentsCollectionChanged;
         PendingAttachmentItems.CollectionChanged += OnPendingAttachmentItemsCollectionChanged;
 
         RefreshComposerCatalogs();
@@ -763,6 +765,11 @@ public partial class ChatViewModel
     private void OnPendingAttachmentItemsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         OnPropertyChanged(nameof(HasPendingAttachments));
+    }
+
+    private void OnPendingAttachmentsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        OnPropertyChanged(nameof(HasSendablePendingAttachments));
     }
 
     private void OnActiveSkillChipsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs args)

--- a/src/Lumi/ViewModels/ChatViewModel.cs
+++ b/src/Lumi/ViewModels/ChatViewModel.cs
@@ -1515,6 +1515,23 @@ public partial class ChatViewModel : ObservableObject
             ? "Please use the attached file as context."
             : "Please use the attached files as context.";
 
+    internal static List<string> GetChatMessageAttachmentPaths(IEnumerable<UserMessageAttachment>? attachments)
+    {
+        if (attachments is null)
+            return [];
+
+        return attachments
+            .Select(static attachment => attachment switch
+            {
+                UserMessageAttachmentFile file => file.Path,
+                UserMessageAttachmentDirectory directory => directory.Path,
+                _ => null
+            })
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .Select(static path => path!)
+            .ToList();
+    }
+
     private async Task SendMessageCore(string? promptText, bool consumeComposerPrompt)
     {
         var hasPendingAttachments = PendingAttachments.Count > 0;
@@ -1627,7 +1644,7 @@ public partial class ChatViewModel : ObservableObject
                 Role = "user",
                 Content = prompt,
                 Author = _dataStore.Data.Settings.UserName ?? Loc.Author_You,
-                Attachments = attachments?.OfType<UserMessageAttachmentFile>().Select(a => a.Path).ToList() ?? [],
+                Attachments = GetChatMessageAttachmentPaths(attachments),
                 ActiveSkills = BuildSkillReferences(ActiveSkillIds, _activeExternalSkillNames)
             };
             targetChat.Messages.Add(userMsg);

--- a/src/Lumi/ViewModels/ChatViewModel.cs
+++ b/src/Lumi/ViewModels/ChatViewModel.cs
@@ -132,6 +132,8 @@ public partial class ChatViewModel : ObservableObject
     private Guid? _suggestionDisplayChatId;
     /// <summary>Maps chat ID → unsent composer draft text. Guid.Empty is used for the "new chat" state.</summary>
     private readonly Dictionary<Guid, string> _chatDrafts = new();
+    /// <summary>Maps chat ID → unsent composer attachment paths. Guid.Empty is used for the "new chat" state.</summary>
+    private readonly Dictionary<Guid, List<string>> _chatDraftAttachmentPaths = new();
     /// <summary>Maps chat ID → turn submitted while the chat was busy. Drained after the active turn stops.</summary>
     private readonly Dictionary<Guid, QueuedBusySend> _queuedBusySendPrompts = new();
     /// <summary>Tracks the last assistant message ID that already produced suggestions per chat.</summary>
@@ -908,13 +910,7 @@ public partial class ChatViewModel : ObservableObject
         if (CurrentChat?.Id != chat.Id)
         {
             _suggestionDisplayChatId = chat.Id;
-
-            // Save unsent composer draft for the chat we're leaving
-            var leavingId = CurrentChat?.Id ?? Guid.Empty;
-            if (!string.IsNullOrEmpty(PromptText))
-                _chatDrafts[leavingId] = PromptText!;
-            else
-                _chatDrafts.Remove(leavingId);
+            SaveComposerDraft(CurrentChat?.Id ?? Guid.Empty);
 
             BrowserHideRequested?.Invoke();
             DiffHideRequested?.Invoke();
@@ -973,8 +969,7 @@ public partial class ChatViewModel : ObservableObject
                 CurrentChat = chat;
                 chat.HasUnreadMessages = false; // Clear unread when switching to this chat
 
-                // Restore unsent composer draft for this chat
-                PromptText = _chatDrafts.TryGetValue(chat.Id, out var draft) ? draft : "";
+                RestoreComposerDraft(chat.Id);
                 RestoreSuggestionsForChat(chat);
 
                 if (previousChat is not null)
@@ -1151,12 +1146,7 @@ public partial class ChatViewModel : ObservableObject
             catch (ObjectDisposedException) { }
         }
 
-        // Save unsent composer draft for the chat we're leaving
-        var leavingId = CurrentChat?.Id ?? Guid.Empty;
-        if (!string.IsNullOrEmpty(PromptText))
-            _chatDrafts[leavingId] = PromptText!;
-        else
-            _chatDrafts.Remove(leavingId);
+        SaveComposerDraft(CurrentChat?.Id ?? Guid.Empty);
 
         BrowserHideRequested?.Invoke();
         DiffHideRequested?.Invoke();
@@ -1204,8 +1194,7 @@ public partial class ChatViewModel : ObservableObject
         SelectedSdkAgentName = null;
         SdkAgentChips.Clear();
 
-        // Restore unsent composer draft for the "new chat" state
-        PromptText = _chatDrafts.TryGetValue(Guid.Empty, out var draft) ? draft : "";
+        RestoreComposerDraft(Guid.Empty);
 
         SyncComposerProjectSelectionFromState();
         RefreshProjectBadge();
@@ -1517,6 +1506,53 @@ public partial class ChatViewModel : ObservableObject
             ? "Please use the attached file as context."
             : "Please use the attached files as context.";
 
+    private void SaveComposerDraft(Guid chatId)
+    {
+        SaveChatDraft(chatId, PromptText, PendingAttachmentItems.Select(static item => item.FilePath));
+    }
+
+    private void SaveChatDraft(Guid chatId, string? promptText, IEnumerable<string>? attachmentPaths)
+    {
+        if (!string.IsNullOrEmpty(promptText))
+            _chatDrafts[chatId] = promptText!;
+        else
+            _chatDrafts.Remove(chatId);
+
+        var paths = attachmentPaths?
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList() ?? [];
+
+        if (paths.Count > 0)
+            _chatDraftAttachmentPaths[chatId] = paths;
+        else
+            _chatDraftAttachmentPaths.Remove(chatId);
+    }
+
+    private void ClearComposerDraft(Guid chatId)
+    {
+        _chatDrafts.Remove(chatId);
+        _chatDraftAttachmentPaths.Remove(chatId);
+    }
+
+    private void RestoreComposerDraft(Guid chatId)
+    {
+        PromptText = _chatDrafts.TryGetValue(chatId, out var draft) ? draft : "";
+        RestoreDraftAttachments(chatId);
+    }
+
+    private void RestoreDraftAttachments(Guid chatId)
+    {
+        PendingAttachments.Clear();
+        PendingAttachmentItems.Clear();
+
+        if (!_chatDraftAttachmentPaths.TryGetValue(chatId, out var attachmentPaths))
+            return;
+
+        foreach (var attachmentPath in attachmentPaths)
+            AddAttachment(attachmentPath);
+    }
+
     internal static List<string> GetChatMessageAttachmentPaths(IEnumerable<UserMessageAttachment>? attachments)
     {
         if (attachments is null)
@@ -1558,7 +1594,7 @@ public partial class ChatViewModel : ObservableObject
             if (consumeComposerPrompt)
             {
                 PromptText = "";
-                _chatDrafts.Remove(activeChat.Id);
+                ClearComposerDraft(activeChat.Id);
                 if (hasAttachments && attachmentPathSnapshot is null)
                 {
                     PendingAttachments.Clear();
@@ -1589,9 +1625,12 @@ public partial class ChatViewModel : ObservableObject
                 StatusText = Loc.Status_CheckAccess;
                 if (!consumeComposerPrompt && CurrentChat is not null)
                 {
-                    _chatDrafts[CurrentChat.Id] = prompt;
+                    SaveChatDraft(CurrentChat.Id, prompt, attachmentPaths);
                     if (string.IsNullOrWhiteSpace(PromptText))
+                    {
                         PromptText = prompt;
+                        RestoreDraftAttachments(CurrentChat.Id);
+                    }
                 }
 
                 return;
@@ -1601,7 +1640,7 @@ public partial class ChatViewModel : ObservableObject
         if (consumeComposerPrompt)
         {
             PromptText = "";
-            _chatDrafts.Remove(CurrentChat?.Id ?? Guid.Empty);
+            ClearComposerDraft(CurrentChat?.Id ?? Guid.Empty);
         }
         ClearSuggestions();
         var selectedReasoningEffort = GetPersistedReasoningEffortPreference();

--- a/src/Lumi/ViewModels/ChatViewModel.cs
+++ b/src/Lumi/ViewModels/ChatViewModel.cs
@@ -132,10 +132,12 @@ public partial class ChatViewModel : ObservableObject
     private Guid? _suggestionDisplayChatId;
     /// <summary>Maps chat ID → unsent composer draft text. Guid.Empty is used for the "new chat" state.</summary>
     private readonly Dictionary<Guid, string> _chatDrafts = new();
-    /// <summary>Maps chat ID → prompt submitted while the chat was busy. Drained after the active turn stops.</summary>
-    private readonly Dictionary<Guid, string> _queuedBusySendPrompts = new();
+    /// <summary>Maps chat ID → turn submitted while the chat was busy. Drained after the active turn stops.</summary>
+    private readonly Dictionary<Guid, QueuedBusySend> _queuedBusySendPrompts = new();
     /// <summary>Tracks the last assistant message ID that already produced suggestions per chat.</summary>
     private readonly Dictionary<Guid, Guid> _lastSuggestedAssistantMessageByChat = new();
+
+    private sealed record QueuedBusySend(string Prompt, IReadOnlyList<string> AttachmentPaths);
 
     /// <summary>Gets or lazily creates a per-chat BrowserService instance.</summary>
     private BrowserService GetOrCreateBrowserService(Guid chatId)
@@ -1532,28 +1534,42 @@ public partial class ChatViewModel : ObservableObject
             .ToList();
     }
 
-    private async Task SendMessageCore(string? promptText, bool consumeComposerPrompt)
+    private Task SendMessageCore(string? promptText, bool consumeComposerPrompt)
+        => SendMessageCore(promptText, consumeComposerPrompt, attachmentPathSnapshot: null);
+
+    private async Task SendMessageCore(
+        string? promptText,
+        bool consumeComposerPrompt,
+        IReadOnlyCollection<string>? attachmentPathSnapshot)
     {
-        var hasPendingAttachments = PendingAttachments.Count > 0;
-        if (string.IsNullOrWhiteSpace(promptText) && !hasPendingAttachments)
+        var attachmentPaths = attachmentPathSnapshot is not null
+            ? attachmentPathSnapshot.Where(static path => !string.IsNullOrWhiteSpace(path)).ToList()
+            : PendingAttachments.Where(static path => !string.IsNullOrWhiteSpace(path)).ToList();
+        var hasAttachments = attachmentPaths.Count > 0;
+        if (string.IsNullOrWhiteSpace(promptText) && !hasAttachments)
             return;
 
         var prompt = string.IsNullOrWhiteSpace(promptText)
-            ? BuildAttachmentOnlyPrompt(PendingAttachments.Count)
+            ? BuildAttachmentOnlyPrompt(attachmentPaths.Count)
             : promptText.Trim();
         if (CurrentChat is { } activeChat && IsChatRuntimeActive(activeChat.Id))
         {
-            QueueBusySendPrompt(activeChat.Id, prompt);
+            QueueBusySendPrompt(activeChat.Id, prompt, attachmentPaths);
             if (consumeComposerPrompt)
             {
                 PromptText = "";
                 _chatDrafts.Remove(activeChat.Id);
+                if (hasAttachments && attachmentPathSnapshot is null)
+                {
+                    PendingAttachments.Clear();
+                    PendingAttachmentItems.Clear();
+                }
             }
 
             return;
         }
 
-        var preparedAttachments = PrepareSdkAttachmentsForPaths(PendingAttachments);
+        var preparedAttachments = PrepareSdkAttachmentsForPaths(attachmentPaths);
         if (!preparedAttachments.Success)
         {
             StatusText = preparedAttachments.ErrorMessage ?? "Could not prepare the attachment for Copilot.";
@@ -1594,7 +1610,7 @@ public partial class ChatViewModel : ObservableObject
         if (CurrentChat is not null)
             CancelPendingQuestions(CurrentChat);
 
-        if (attachments is not null)
+        if (attachments is not null && attachmentPathSnapshot is null)
         {
             PendingAttachments.Clear();
             PendingAttachmentItems.Clear();

--- a/src/Lumi/ViewModels/ChatViewModel.cs
+++ b/src/Lumi/ViewModels/ChatViewModel.cs
@@ -1570,6 +1570,53 @@ public partial class ChatViewModel : ObservableObject
             .ToList();
     }
 
+    private List<string> GetAttachmentPathsReadyForSend(IReadOnlyCollection<string>? attachmentPathSnapshot)
+    {
+        var attachmentPaths = attachmentPathSnapshot is not null
+            ? attachmentPathSnapshot.Where(static path => !string.IsNullOrWhiteSpace(path)).ToList()
+            : PendingAttachments.Where(static path => !string.IsNullOrWhiteSpace(path)).ToList();
+
+        if (attachmentPathSnapshot is not null)
+            return attachmentPaths;
+
+        var sendablePaths = new List<string>(attachmentPaths.Count);
+        foreach (var path in attachmentPaths)
+        {
+            var validationError = AttachmentPreparationService.ValidatePendingPath(path);
+            if (validationError is null)
+            {
+                sendablePaths.Add(path);
+                continue;
+            }
+
+            MarkPendingAttachmentFailed(path, validationError);
+            StatusText = validationError;
+        }
+
+        return sendablePaths;
+    }
+
+    private void MarkPendingAttachmentFailed(string filePath, string errorMessage)
+    {
+        PendingAttachments.Remove(filePath);
+
+        var pendingItem = PendingAttachmentItems.FirstOrDefault(item =>
+            string.Equals(item.FilePath, filePath, StringComparison.OrdinalIgnoreCase));
+        if (pendingItem is not null)
+        {
+            pendingItem.MarkFailed(errorMessage);
+            UpdatePendingAttachmentErrorText();
+            return;
+        }
+
+        PendingAttachmentItems.Add(new FileAttachmentItem(
+            filePath,
+            isRemovable: true,
+            removeAction: RemoveAttachment,
+            status: StrataAttachmentStatus.Failed,
+            errorMessage: errorMessage));
+    }
+
     private Task SendMessageCore(string? promptText, bool consumeComposerPrompt)
         => SendMessageCore(promptText, consumeComposerPrompt, attachmentPathSnapshot: null);
 
@@ -1578,9 +1625,7 @@ public partial class ChatViewModel : ObservableObject
         bool consumeComposerPrompt,
         IReadOnlyCollection<string>? attachmentPathSnapshot)
     {
-        var attachmentPaths = attachmentPathSnapshot is not null
-            ? attachmentPathSnapshot.Where(static path => !string.IsNullOrWhiteSpace(path)).ToList()
-            : PendingAttachments.Where(static path => !string.IsNullOrWhiteSpace(path)).ToList();
+        var attachmentPaths = GetAttachmentPathsReadyForSend(attachmentPathSnapshot);
         var hasAttachments = attachmentPaths.Count > 0;
         if (string.IsNullOrWhiteSpace(promptText) && !hasAttachments)
             return;

--- a/src/Lumi/ViewModels/ChatViewModel.cs
+++ b/src/Lumi/ViewModels/ChatViewModel.cs
@@ -1510,12 +1510,20 @@ public partial class ChatViewModel : ObservableObject
         await SendMessageCore(PromptText, consumeComposerPrompt: true);
     }
 
+    private static string BuildAttachmentOnlyPrompt(int attachmentCount)
+        => attachmentCount == 1
+            ? "Please use the attached file as context."
+            : "Please use the attached files as context.";
+
     private async Task SendMessageCore(string? promptText, bool consumeComposerPrompt)
     {
-        if (string.IsNullOrWhiteSpace(promptText))
+        var hasPendingAttachments = PendingAttachments.Count > 0;
+        if (string.IsNullOrWhiteSpace(promptText) && !hasPendingAttachments)
             return;
 
-        var prompt = promptText.Trim();
+        var prompt = string.IsNullOrWhiteSpace(promptText)
+            ? BuildAttachmentOnlyPrompt(PendingAttachments.Count)
+            : promptText.Trim();
         if (CurrentChat is { } activeChat && IsChatRuntimeActive(activeChat.Id))
         {
             QueueBusySendPrompt(activeChat.Id, prompt);
@@ -1527,6 +1535,17 @@ public partial class ChatViewModel : ObservableObject
 
             return;
         }
+
+        var preparedAttachments = PrepareSdkAttachmentsForPaths(PendingAttachments);
+        if (!preparedAttachments.Success)
+        {
+            StatusText = preparedAttachments.ErrorMessage ?? "Could not prepare the attachment for Copilot.";
+            return;
+        }
+
+        var attachments = preparedAttachments.Attachments.Count > 0
+            ? preparedAttachments.Attachments
+            : null;
 
         if (!_copilotService.IsConnected)
         {
@@ -1558,7 +1577,12 @@ public partial class ChatViewModel : ObservableObject
         if (CurrentChat is not null)
             CancelPendingQuestions(CurrentChat);
 
-        var attachments = TakePendingAttachments();
+        if (attachments is not null)
+        {
+            PendingAttachments.Clear();
+            PendingAttachmentItems.Clear();
+        }
+
         var createdChat = false;
 
         // Create chat if needed
@@ -3110,6 +3134,17 @@ public partial class ChatViewModel : ObservableObject
         if (idx < 0) return;
 
         var prompt = userMessage.Content;
+        var attachmentPaths = userMessage.Attachments.ToList();
+        var preparedAttachments = PrepareSdkAttachmentsForPaths(attachmentPaths);
+        if (!preparedAttachments.Success)
+        {
+            StatusText = preparedAttachments.ErrorMessage ?? "Could not prepare the attachment for Copilot.";
+            return;
+        }
+
+        var resendAttachments = preparedAttachments.Attachments.Count > 0
+            ? preparedAttachments.Attachments
+            : null;
 
         // Remove the user message and everything after it
         while (CurrentChat.Messages.Count > idx)
@@ -3143,7 +3178,9 @@ public partial class ChatViewModel : ObservableObject
         {
             Role = "user",
             Content = prompt,
-            Author = userMessage.Author
+            Author = userMessage.Author,
+            Attachments = [..attachmentPaths],
+            ActiveSkills = [..userMessage.ActiveSkills]
         };
         CurrentChat.Messages.Add(newUserMsg);
         Messages.Add(new ChatMessageViewModel(newUserMsg));
@@ -3255,6 +3292,8 @@ public partial class ChatViewModel : ObservableObject
                 promptAdditions);
 
             resendOptions = new MessageOptions { Prompt = resendPrompt };
+            if (resendAttachments is not null)
+                resendOptions.Attachments = resendAttachments;
             localUserMessageCount = CurrentChat.Messages.Count(m => m.Role == "user");
             localAssistantMessageCount = CountCompletedAssistantMessages(CurrentChat);
             var expectedSessionUserMessageCount = await CaptureExpectedSessionUserMessageCountAsync(
@@ -3293,6 +3332,8 @@ public partial class ChatViewModel : ObservableObject
                     shouldReplayPrompt: !wasEdited,
                     promptAdditions);
                 resendOptions = new MessageOptions { Prompt = resendPrompt2 };
+                if (resendAttachments is not null)
+                    resendOptions.Attachments = resendAttachments;
                 var expectedSessionUserMessageCount = await CaptureExpectedSessionUserMessageCountAsync(
                     _activeSession!,
                     localUserMessageCount,

--- a/src/Lumi/ViewModels/TranscriptItems.cs
+++ b/src/Lumi/ViewModels/TranscriptItems.cs
@@ -753,13 +753,22 @@ public partial class FileAttachmentItem : ObservableObject
     public string FileName { get; }
     public string? FileSize { get; }
     public bool IsRemovable { get; }
+    public StrataAttachmentStatus Status { get; }
+    public string? ErrorMessage { get; }
     public Avalonia.Media.Imaging.Bitmap? IconImage { get; }
 
-    public FileAttachmentItem(string filePath, bool isRemovable = false, Action<string>? removeAction = null)
+    public FileAttachmentItem(
+        string filePath,
+        bool isRemovable = false,
+        Action<string>? removeAction = null,
+        StrataAttachmentStatus status = StrataAttachmentStatus.Completed,
+        string? errorMessage = null)
     {
         FilePath = filePath;
         FileName = Path.GetFileName(filePath);
         IsRemovable = isRemovable;
+        Status = status;
+        ErrorMessage = errorMessage;
         _removeAction = removeAction;
 
         try

--- a/src/Lumi/ViewModels/TranscriptItems.cs
+++ b/src/Lumi/ViewModels/TranscriptItems.cs
@@ -753,9 +753,9 @@ public partial class FileAttachmentItem : ObservableObject
     public string FileName { get; }
     public string? FileSize { get; }
     public bool IsRemovable { get; }
-    public StrataAttachmentStatus Status { get; }
-    public string? ErrorMessage { get; }
     public Avalonia.Media.Imaging.Bitmap? IconImage { get; }
+    [ObservableProperty] private StrataAttachmentStatus _status;
+    [ObservableProperty] private string? _errorMessage;
 
     public FileAttachmentItem(
         string filePath,
@@ -780,6 +780,12 @@ public partial class FileAttachmentItem : ObservableObject
         catch { /* ignore */ }
 
         IconImage = Services.FileIconHelper.GetFileIcon(filePath);
+    }
+
+    public void MarkFailed(string errorMessage)
+    {
+        Status = StrataAttachmentStatus.Failed;
+        ErrorMessage = errorMessage;
     }
 
     [RelayCommand]

--- a/src/Lumi/ViewModels/UiThrottler.cs
+++ b/src/Lumi/ViewModels/UiThrottler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Threading;
@@ -102,9 +103,10 @@ internal sealed class UiThrottler(Action action, TimeSpan minimumInterval, Dispa
         {
             // Token was cancelled — the caller has already scheduled a replacement.
         }
-        catch
+        catch (Exception ex)
         {
             // Unexpected error — reset _scheduled so future requests aren't permanently blocked.
+            Trace.TraceError("UiThrottler scheduling failed: {0}", ex);
             lock (_gate)
             {
                 _scheduled = false;
@@ -125,6 +127,13 @@ internal sealed class UiThrottler(Action action, TimeSpan minimumInterval, Dispa
             _lastRunUtc = DateTime.UtcNow;
         }
 
-        _action();
+        try
+        {
+            _action();
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("UiThrottler action failed: {0}", ex);
+        }
     }
 }

--- a/src/Lumi/Views/ChatView.axaml
+++ b/src/Lumi/Views/ChatView.axaml
@@ -428,11 +428,11 @@
                       <ItemsPanelTemplate><WrapPanel /></ItemsPanelTemplate>
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>
-                      <DataTemplate DataType="vm:FileAttachmentItem">
-                        <sc:StrataFileAttachment FileName="{Binding FileName}"
-                                                 FileSize="{Binding FileSize}"
-                                                 IconImage="{Binding IconImage}"
-                                                 Status="{Binding Status}"
+                <DataTemplate DataType="vm:FileAttachmentItem">
+                  <sc:StrataFileAttachment FileName="{Binding FileName}"
+                                           FileSize="{Binding FileSize}"
+                                           IconImage="{Binding IconImage}"
+                                           Status="{Binding Status}"
                                                  ToolTip.Tip="{Binding ErrorMessage}"
                                                  IsRemovable="False" />
                       </DataTemplate>
@@ -1487,23 +1487,30 @@
           </DataTemplate>
         </sc:StrataChatComposer.ModelItemTemplate>
         <sc:StrataChatComposer.AttachmentContent>
-          <sc:StrataAttachmentList ShowAddButton="False"
-                                   ItemsSource="{Binding PendingAttachmentItems}"
-                                   IsVisible="{Binding HasPendingAttachments}">
-            <sc:StrataAttachmentList.ItemTemplate>
-              <DataTemplate DataType="vm:FileAttachmentItem">
-                <sc:StrataFileAttachment FileName="{Binding FileName}"
-                                         FileSize="{Binding FileSize}"
-                                         IconImage="{Binding IconImage}"
-                                         Status="{Binding Status}"
-                                         ToolTip.Tip="{Binding ErrorMessage}"
-                                         IsCompact="True"
-                                         IsRemovable="{Binding IsRemovable}"
-                                         RemoveCommand="{Binding RemoveCommand}"
-                                         Margin="0,0,6,4" />
-              </DataTemplate>
-            </sc:StrataAttachmentList.ItemTemplate>
-          </sc:StrataAttachmentList>
+          <StackPanel Spacing="4">
+            <sc:StrataAttachmentList ShowAddButton="False"
+                                     ItemsSource="{Binding PendingAttachmentItems}"
+                                     IsVisible="{Binding HasPendingAttachments}">
+              <sc:StrataAttachmentList.ItemTemplate>
+                <DataTemplate DataType="vm:FileAttachmentItem">
+                  <sc:StrataFileAttachment FileName="{Binding FileName}"
+                                           FileSize="{Binding FileSize}"
+                                           IconImage="{Binding IconImage}"
+                                           Status="{Binding Status}"
+                                           ToolTip.Tip="{Binding ErrorMessage}"
+                                           IsCompact="True"
+                                           IsRemovable="{Binding IsRemovable}"
+                                           RemoveCommand="{Binding RemoveCommand}"
+                                           Margin="0,0,6,4" />
+                </DataTemplate>
+              </sc:StrataAttachmentList.ItemTemplate>
+            </sc:StrataAttachmentList>
+            <TextBlock Text="{Binding PendingAttachmentErrorText}"
+                       IsVisible="{Binding HasPendingAttachmentError}"
+                       Classes="caption"
+                       TextWrapping="Wrap"
+                       Foreground="{DynamicResource Brush.DangerDefault}" />
+          </StackPanel>
         </sc:StrataChatComposer.AttachmentContent>
       </sc:StrataChatComposer>
     </StackPanel>

--- a/src/Lumi/Views/ChatView.axaml
+++ b/src/Lumi/Views/ChatView.axaml
@@ -1455,7 +1455,7 @@
                              IsBusy="{Binding IsBusy}"
                              IsRecording="{Binding IsRecording}"
                              SendWithEnter="{Binding SendWithEnter}"
-                             CanSendWithoutPrompt="{Binding HasPendingAttachments}"
+                             CanSendWithoutPrompt="{Binding HasSendablePendingAttachments}"
                              SendCommand="{Binding SendMessageCommand}"
                              StopCommand="{Binding StopGenerationCommand}"
                              AttachCommand="{Binding RequestAttachFilesCommand}"

--- a/src/Lumi/Views/ChatView.axaml
+++ b/src/Lumi/Views/ChatView.axaml
@@ -432,7 +432,8 @@
                         <sc:StrataFileAttachment FileName="{Binding FileName}"
                                                  FileSize="{Binding FileSize}"
                                                  IconImage="{Binding IconImage}"
-                                                 Status="Completed"
+                                                 Status="{Binding Status}"
+                                                 ToolTip.Tip="{Binding ErrorMessage}"
                                                  IsRemovable="False" />
                       </DataTemplate>
                     </ItemsControl.ItemTemplate>
@@ -527,7 +528,8 @@
                         <sc:StrataFileAttachment FileName="{Binding FileName}"
                                                  FileSize="{Binding FileSize}"
                                                  IconImage="{Binding IconImage}"
-                                                 Status="Completed"
+                                                 Status="{Binding Status}"
+                                                 ToolTip.Tip="{Binding ErrorMessage}"
                                                  IsRemovable="False" />
                       </DataTemplate>
                     </ItemsControl.ItemTemplate>
@@ -1492,7 +1494,8 @@
                 <sc:StrataFileAttachment FileName="{Binding FileName}"
                                          FileSize="{Binding FileSize}"
                                          IconImage="{Binding IconImage}"
-                                         Status="Completed"
+                                         Status="{Binding Status}"
+                                         ToolTip.Tip="{Binding ErrorMessage}"
                                          IsCompact="True"
                                          IsRemovable="{Binding IsRemovable}"
                                          RemoveCommand="{Binding RemoveCommand}"

--- a/src/Lumi/Views/ChatView.axaml
+++ b/src/Lumi/Views/ChatView.axaml
@@ -1455,6 +1455,7 @@
                              IsBusy="{Binding IsBusy}"
                              IsRecording="{Binding IsRecording}"
                              SendWithEnter="{Binding SendWithEnter}"
+                             CanSendWithoutPrompt="{Binding HasPendingAttachments}"
                              SendCommand="{Binding SendMessageCommand}"
                              StopCommand="{Binding StopGenerationCommand}"
                              AttachCommand="{Binding RequestAttachFilesCommand}"

--- a/tests/Lumi.Tests/AttachmentPreparationServiceTests.cs
+++ b/tests/Lumi.Tests/AttachmentPreparationServiceTests.cs
@@ -1,4 +1,3 @@
-using System.IO.Compression;
 using GitHub.Copilot.SDK;
 using Lumi.Services;
 using Xunit;
@@ -24,7 +23,7 @@ public class AttachmentPreparationServiceTests : IDisposable
     public void PrepareForCopilot_ValidDocx_UsesSdkFileAttachment()
     {
         var path = Path.Combine(_tempDir, "contract.docx");
-        CreateMinimalDocx(path);
+        File.WriteAllText(path, "docx bytes are interpreted by the SDK");
 
         var result = AttachmentPreparationService.PrepareForCopilot([path]);
 
@@ -35,48 +34,33 @@ public class AttachmentPreparationServiceTests : IDisposable
     }
 
     [Fact]
-    public void PrepareForCopilot_DocxExtensionOnOleFile_ReturnsActionableError()
+    public void PrepareForCopilot_DocxExtensionOnOleFile_UsesSdkFileAttachment()
     {
         var path = Path.Combine(_tempDir, "legacy-renamed.docx");
         File.WriteAllBytes(path, [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1, 0x00]);
 
         var result = AttachmentPreparationService.PrepareForCopilot([path]);
 
-        Assert.False(result.Success);
-        Assert.Empty(result.Attachments);
-        Assert.Contains("older or encrypted Word/OLE document", result.ErrorMessage);
-        Assert.Contains("Re-save it as a modern .docx", result.ErrorMessage);
+        Assert.True(result.Success);
+        var file = Assert.IsType<UserMessageAttachmentFile>(Assert.Single(result.Attachments));
+        Assert.Equal(Path.GetFullPath(path), file.Path);
+        Assert.Equal("legacy-renamed.docx", file.DisplayName);
+        Assert.Null(result.ErrorMessage);
     }
 
     [Fact]
-    public void PrepareForCopilot_InvalidDocxZip_ReturnsClearError()
+    public void PrepareForCopilot_InvalidDocxContent_UsesSdkFileAttachment()
     {
         var path = Path.Combine(_tempDir, "not-word.docx");
         File.WriteAllText(path, "not a zip file");
 
         var result = AttachmentPreparationService.PrepareForCopilot([path]);
 
-        Assert.False(result.Success);
-        Assert.Empty(result.Attachments);
-        Assert.Contains("not a valid modern Word document", result.ErrorMessage);
-    }
-
-    [Fact]
-    public void PrepareForCopilot_ZipMissingWordParts_ReturnsClearError()
-    {
-        var path = Path.Combine(_tempDir, "plain-zip.docx");
-        using (var archive = ZipFile.Open(path, ZipArchiveMode.Create))
-        {
-            var entry = archive.CreateEntry("readme.txt");
-            using var writer = new StreamWriter(entry.Open());
-            writer.Write("hello");
-        }
-
-        var result = AttachmentPreparationService.PrepareForCopilot([path]);
-
-        Assert.False(result.Success);
-        Assert.Empty(result.Attachments);
-        Assert.Contains("missing required Word document parts", result.ErrorMessage);
+        Assert.True(result.Success);
+        var file = Assert.IsType<UserMessageAttachmentFile>(Assert.Single(result.Attachments));
+        Assert.Equal(Path.GetFullPath(path), file.Path);
+        Assert.Equal("not-word.docx", file.DisplayName);
+        Assert.Null(result.ErrorMessage);
     }
 
     [Fact]
@@ -103,31 +87,5 @@ public class AttachmentPreparationServiceTests : IDisposable
         Assert.False(result.Success);
         Assert.Empty(result.Attachments);
         Assert.Contains("Attachment not found", result.ErrorMessage);
-    }
-
-    private static void CreateMinimalDocx(string path)
-    {
-        using var archive = ZipFile.Open(path, ZipArchiveMode.Create);
-        WriteEntry(archive, "[Content_Types].xml", """
-            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-            <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
-              <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
-              <Default Extension="xml" ContentType="application/xml"/>
-              <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
-            </Types>
-            """);
-        WriteEntry(archive, "word/document.xml", """
-            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-            <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-              <w:body><w:p><w:r><w:t>Hello from DOCX</w:t></w:r></w:p></w:body>
-            </w:document>
-            """);
-    }
-
-    private static void WriteEntry(ZipArchive archive, string name, string content)
-    {
-        var entry = archive.CreateEntry(name);
-        using var writer = new StreamWriter(entry.Open());
-        writer.Write(content);
     }
 }

--- a/tests/Lumi.Tests/AttachmentPreparationServiceTests.cs
+++ b/tests/Lumi.Tests/AttachmentPreparationServiceTests.cs
@@ -1,0 +1,133 @@
+using System.IO.Compression;
+using GitHub.Copilot.SDK;
+using Lumi.Services;
+using Xunit;
+
+namespace Lumi.Tests;
+
+public class AttachmentPreparationServiceTests : IDisposable
+{
+    private readonly string _tempDir = Path.Combine(Path.GetTempPath(), $"lumi-attachments-{Guid.NewGuid():N}");
+
+    public AttachmentPreparationServiceTests()
+    {
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public void PrepareForCopilot_ValidDocx_UsesSdkFileAttachment()
+    {
+        var path = Path.Combine(_tempDir, "contract.docx");
+        CreateMinimalDocx(path);
+
+        var result = AttachmentPreparationService.PrepareForCopilot([path]);
+
+        Assert.True(result.Success);
+        var file = Assert.IsType<UserMessageAttachmentFile>(Assert.Single(result.Attachments));
+        Assert.Equal(Path.GetFullPath(path), file.Path);
+        Assert.Equal("contract.docx", file.DisplayName);
+    }
+
+    [Fact]
+    public void PrepareForCopilot_DocxExtensionOnOleFile_ReturnsActionableError()
+    {
+        var path = Path.Combine(_tempDir, "legacy-renamed.docx");
+        File.WriteAllBytes(path, [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1, 0x00]);
+
+        var result = AttachmentPreparationService.PrepareForCopilot([path]);
+
+        Assert.False(result.Success);
+        Assert.Empty(result.Attachments);
+        Assert.Contains("older or encrypted Word/OLE document", result.ErrorMessage);
+        Assert.Contains("Re-save it as a modern .docx", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void PrepareForCopilot_InvalidDocxZip_ReturnsClearError()
+    {
+        var path = Path.Combine(_tempDir, "not-word.docx");
+        File.WriteAllText(path, "not a zip file");
+
+        var result = AttachmentPreparationService.PrepareForCopilot([path]);
+
+        Assert.False(result.Success);
+        Assert.Empty(result.Attachments);
+        Assert.Contains("not a valid modern Word document", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void PrepareForCopilot_ZipMissingWordParts_ReturnsClearError()
+    {
+        var path = Path.Combine(_tempDir, "plain-zip.docx");
+        using (var archive = ZipFile.Open(path, ZipArchiveMode.Create))
+        {
+            var entry = archive.CreateEntry("readme.txt");
+            using var writer = new StreamWriter(entry.Open());
+            writer.Write("hello");
+        }
+
+        var result = AttachmentPreparationService.PrepareForCopilot([path]);
+
+        Assert.False(result.Success);
+        Assert.Empty(result.Attachments);
+        Assert.Contains("missing required Word document parts", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void PrepareForCopilot_Directory_UsesSdkDirectoryAttachment()
+    {
+        var path = Path.Combine(_tempDir, "folder");
+        Directory.CreateDirectory(path);
+
+        var result = AttachmentPreparationService.PrepareForCopilot([path]);
+
+        Assert.True(result.Success);
+        var directory = Assert.IsType<UserMessageAttachmentDirectory>(Assert.Single(result.Attachments));
+        Assert.Equal(Path.GetFullPath(path), directory.Path);
+        Assert.Equal("folder", directory.DisplayName);
+    }
+
+    [Fact]
+    public void PrepareForCopilot_MissingPath_ReturnsError()
+    {
+        var path = Path.Combine(_tempDir, "missing.docx");
+
+        var result = AttachmentPreparationService.PrepareForCopilot([path]);
+
+        Assert.False(result.Success);
+        Assert.Empty(result.Attachments);
+        Assert.Contains("Attachment not found", result.ErrorMessage);
+    }
+
+    private static void CreateMinimalDocx(string path)
+    {
+        using var archive = ZipFile.Open(path, ZipArchiveMode.Create);
+        WriteEntry(archive, "[Content_Types].xml", """
+            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+            <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+              <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+              <Default Extension="xml" ContentType="application/xml"/>
+              <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+            </Types>
+            """);
+        WriteEntry(archive, "word/document.xml", """
+            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+            <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+              <w:body><w:p><w:r><w:t>Hello from DOCX</w:t></w:r></w:p></w:body>
+            </w:document>
+            """);
+    }
+
+    private static void WriteEntry(ZipArchive archive, string name, string content)
+    {
+        var entry = archive.CreateEntry(name);
+        using var writer = new StreamWriter(entry.Open());
+        writer.Write(content);
+    }
+}

--- a/tests/Lumi.Tests/ChatViewModelLeakTests.cs
+++ b/tests/Lumi.Tests/ChatViewModelLeakTests.cs
@@ -177,6 +177,24 @@ public sealed class ChatViewModelLeakTests
     }
 
     [Fact]
+    public void AddAttachment_WhenPathIsInvalid_ShowsFailedChipWithoutSendableAttachment()
+    {
+        var dataStore = CreateDataStore();
+        var vm = new ChatViewModel(dataStore, new CopilotService());
+        var missingPath = Path.Combine(Path.GetTempPath(), $"lumi-missing-{Guid.NewGuid():N}.txt");
+
+        vm.AddAttachment(missingPath);
+
+        Assert.Empty(vm.PendingAttachments);
+        Assert.True(vm.HasPendingAttachments);
+        Assert.False(vm.HasSendablePendingAttachments);
+        var item = Assert.Single(vm.PendingAttachmentItems);
+        Assert.Equal(missingPath, item.FilePath);
+        Assert.Equal(StrataTheme.Controls.StrataAttachmentStatus.Failed, item.Status);
+        Assert.Contains("Attachment not found", item.ErrorMessage);
+    }
+
+    [Fact]
     public async Task SendMessageCore_WhenQueuedPromptFindsRuntimeStillActive_DoesNotOverwriteDraft()
     {
         var dataStore = CreateDataStore();

--- a/tests/Lumi.Tests/ChatViewModelLeakTests.cs
+++ b/tests/Lumi.Tests/ChatViewModelLeakTests.cs
@@ -188,8 +188,74 @@ public sealed class ChatViewModelLeakTests
         Assert.Empty(vm.PendingAttachments);
         Assert.True(vm.HasPendingAttachments);
         Assert.False(vm.HasSendablePendingAttachments);
+        Assert.True(vm.HasPendingAttachmentError);
+        Assert.Contains("Attachment not found", vm.PendingAttachmentErrorText);
         var item = Assert.Single(vm.PendingAttachmentItems);
         Assert.Equal(missingPath, item.FilePath);
+        Assert.Equal(StrataTheme.Controls.StrataAttachmentStatus.Failed, item.Status);
+        Assert.Contains("Attachment not found", item.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task SendMessage_WhenPendingAttachmentWasDeleted_MarksChipFailedWithoutSendingAttachmentOnly()
+    {
+        var dataStore = CreateDataStore();
+        var vm = new ChatViewModel(dataStore, new CopilotService());
+        var chat = new Chat { Title = "attachment-chat" };
+        var attachmentPath = Path.GetTempFileName();
+
+        dataStore.Data.Chats.Add(chat);
+        vm.CurrentChat = chat;
+        vm.AddAttachment(attachmentPath);
+        File.Delete(attachmentPath);
+
+        await InvokePrivateAsync(vm, "SendMessage");
+
+        Assert.Empty(chat.Messages);
+        Assert.Empty(vm.PendingAttachments);
+        Assert.True(vm.HasPendingAttachments);
+        Assert.False(vm.HasSendablePendingAttachments);
+        Assert.True(vm.HasPendingAttachmentError);
+        Assert.Contains("Attachment not found", vm.StatusText);
+        Assert.Contains("Attachment not found", vm.PendingAttachmentErrorText);
+        var item = Assert.Single(vm.PendingAttachmentItems);
+        Assert.Equal(attachmentPath, item.FilePath);
+        Assert.Equal(StrataTheme.Controls.StrataAttachmentStatus.Failed, item.Status);
+        Assert.Contains("Attachment not found", item.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task SendMessage_WhenPendingAttachmentWasDeleted_QueuesTextWithoutStaleAttachment()
+    {
+        var dataStore = CreateDataStore();
+        var vm = new ChatViewModel(dataStore, new CopilotService());
+        var chat = new Chat { Title = "busy-chat" };
+        var attachmentPath = Path.GetTempFileName();
+
+        dataStore.Data.Chats.Add(chat);
+        vm.CurrentChat = chat;
+        vm.PromptText = "send the text";
+        vm.AddAttachment(attachmentPath);
+        File.Delete(attachmentPath);
+        GetField<Dictionary<Guid, ChatRuntimeState>>(vm, "_runtimeStates")[chat.Id] = new ChatRuntimeState
+        {
+            Chat = chat,
+            IsBusy = true
+        };
+
+        await InvokePrivateAsync(vm, "SendMessage");
+
+        Assert.Empty(chat.Messages);
+        Assert.Equal("", vm.PromptText);
+        Assert.Empty(vm.PendingAttachments);
+        Assert.True(vm.HasPendingAttachments);
+        Assert.False(vm.HasSendablePendingAttachments);
+        Assert.True(vm.HasPendingAttachmentError);
+        Assert.Contains("Attachment not found", vm.PendingAttachmentErrorText);
+        Assert.Equal("send the text", GetQueuedBusySendPrompt(vm, chat.Id));
+        Assert.Empty(GetQueuedBusySendAttachmentPaths(vm, chat.Id));
+        var item = Assert.Single(vm.PendingAttachmentItems);
+        Assert.Equal(attachmentPath, item.FilePath);
         Assert.Equal(StrataTheme.Controls.StrataAttachmentStatus.Failed, item.Status);
         Assert.Contains("Attachment not found", item.ErrorMessage);
     }

--- a/tests/Lumi.Tests/ChatViewModelLeakTests.cs
+++ b/tests/Lumi.Tests/ChatViewModelLeakTests.cs
@@ -219,23 +219,62 @@ public sealed class ChatViewModelLeakTests
     }
 
     [Fact]
-    public async Task DrainQueuedBusySendAsync_WhenChatChanged_PreservesQueuedPromptAsDraft()
+    public async Task DrainQueuedBusySendAsync_WhenChatChanged_PreservesQueuedSendAsDraft()
     {
         var dataStore = CreateDataStore();
         var vm = new ChatViewModel(dataStore, new CopilotService());
         var queuedChat = new Chat { Title = "queued-chat" };
         var visibleChat = new Chat { Title = "visible-chat" };
+        var attachmentPath = Path.GetTempFileName();
 
-        dataStore.Data.Chats.Add(queuedChat);
-        dataStore.Data.Chats.Add(visibleChat);
-        vm.CurrentChat = visibleChat;
-        QueueBusySendPrompt(vm, queuedChat.Id, "send me later");
+        try
+        {
+            dataStore.Data.Chats.Add(queuedChat);
+            dataStore.Data.Chats.Add(visibleChat);
+            vm.CurrentChat = visibleChat;
+            QueueBusySendPrompt(vm, queuedChat.Id, "send me later", attachmentPath);
 
-        await InvokePrivateAsync(vm, "DrainQueuedBusySendAsync", queuedChat.Id);
+            await InvokePrivateAsync(vm, "DrainQueuedBusySendAsync", queuedChat.Id);
 
-        Assert.False(GetQueuedBusySends(vm).Contains(queuedChat.Id));
-        Assert.Equal("send me later", GetField<Dictionary<Guid, string>>(vm, "_chatDrafts")[queuedChat.Id]);
-        Assert.Empty(queuedChat.Messages);
+            Assert.False(GetQueuedBusySends(vm).Contains(queuedChat.Id));
+            Assert.Equal("send me later", GetField<Dictionary<Guid, string>>(vm, "_chatDrafts")[queuedChat.Id]);
+            Assert.Equal([attachmentPath], GetChatDraftAttachmentPaths(vm, queuedChat.Id));
+            Assert.Empty(queuedChat.Messages);
+        }
+        finally
+        {
+            File.Delete(attachmentPath);
+        }
+    }
+
+    [Fact]
+    public void RestoreComposerDraft_RestoresDraftPromptAndAttachments()
+    {
+        var dataStore = CreateDataStore();
+        var vm = new ChatViewModel(dataStore, new CopilotService());
+        var chat = new Chat { Title = "draft-chat" };
+        var oldAttachmentPath = Path.GetTempFileName();
+        var draftAttachmentPath = Path.GetTempFileName();
+
+        try
+        {
+            dataStore.Data.Chats.Add(chat);
+            vm.PromptText = "old draft";
+            vm.AddAttachment(oldAttachmentPath);
+            InvokePrivate(vm, "SaveChatDraft", chat.Id, "restored draft", new[] { draftAttachmentPath });
+
+            InvokePrivate(vm, "RestoreComposerDraft", chat.Id);
+
+            Assert.Equal("restored draft", vm.PromptText);
+            Assert.Equal([draftAttachmentPath], vm.PendingAttachments);
+            var item = Assert.Single(vm.PendingAttachmentItems);
+            Assert.Equal(draftAttachmentPath, item.FilePath);
+        }
+        finally
+        {
+            File.Delete(oldAttachmentPath);
+            File.Delete(draftAttachmentPath);
+        }
     }
 
     [Fact]
@@ -975,6 +1014,9 @@ public sealed class ChatViewModelLeakTests
             .GetProperty("AttachmentPaths")
             ?.GetValue(GetQueuedBusySend(vm, chatId))
             ?? throw new InvalidOperationException("Queued send attachment paths were not found."));
+
+    private static IReadOnlyList<string> GetChatDraftAttachmentPaths(ChatViewModel vm, Guid chatId)
+        => GetField<Dictionary<Guid, List<string>>>(vm, "_chatDraftAttachmentPaths")[chatId];
 
     private static void QueueBusySendPrompt(ChatViewModel vm, Guid chatId, string prompt, params string[] attachmentPaths)
     {

--- a/tests/Lumi.Tests/ChatViewModelLeakTests.cs
+++ b/tests/Lumi.Tests/ChatViewModelLeakTests.cs
@@ -147,23 +147,33 @@ public sealed class ChatViewModelLeakTests
         var dataStore = CreateDataStore();
         var vm = new ChatViewModel(dataStore, new CopilotService());
         var chat = new Chat { Title = "busy-chat" };
+        var attachmentPath = Path.GetTempFileName();
 
-        dataStore.Data.Chats.Add(chat);
-        vm.CurrentChat = chat;
-        vm.PromptText = "queued while busy";
-        GetField<Dictionary<Guid, ChatRuntimeState>>(vm, "_runtimeStates")[chat.Id] = new ChatRuntimeState
+        try
         {
-            Chat = chat,
-            IsBusy = true
-        };
+            dataStore.Data.Chats.Add(chat);
+            vm.CurrentChat = chat;
+            vm.PromptText = "queued while busy";
+            vm.AddAttachment(attachmentPath);
+            GetField<Dictionary<Guid, ChatRuntimeState>>(vm, "_runtimeStates")[chat.Id] = new ChatRuntimeState
+            {
+                Chat = chat,
+                IsBusy = true
+            };
 
-        await InvokePrivateAsync(vm, "SendMessage");
+            await InvokePrivateAsync(vm, "SendMessage");
 
-        Assert.Empty(chat.Messages);
-        Assert.Equal("", vm.PromptText);
-        Assert.Equal(
-            "queued while busy",
-            GetField<Dictionary<Guid, string>>(vm, "_queuedBusySendPrompts")[chat.Id]);
+            Assert.Empty(chat.Messages);
+            Assert.Equal("", vm.PromptText);
+            Assert.Empty(vm.PendingAttachments);
+            Assert.Empty(vm.PendingAttachmentItems);
+            Assert.Equal("queued while busy", GetQueuedBusySendPrompt(vm, chat.Id));
+            Assert.Equal([attachmentPath], GetQueuedBusySendAttachmentPaths(vm, chat.Id));
+        }
+        finally
+        {
+            File.Delete(attachmentPath);
+        }
     }
 
     [Fact]
@@ -186,9 +196,8 @@ public sealed class ChatViewModelLeakTests
 
         Assert.Empty(chat.Messages);
         Assert.Equal("new draft", vm.PromptText);
-        Assert.Equal(
-            "queued prompt",
-            GetField<Dictionary<Guid, string>>(vm, "_queuedBusySendPrompts")[chat.Id]);
+        Assert.Equal("queued prompt", GetQueuedBusySendPrompt(vm, chat.Id));
+        Assert.Empty(GetQueuedBusySendAttachmentPaths(vm, chat.Id));
     }
 
     [Fact]
@@ -202,11 +211,11 @@ public sealed class ChatViewModelLeakTests
         dataStore.Data.Chats.Add(queuedChat);
         dataStore.Data.Chats.Add(visibleChat);
         vm.CurrentChat = visibleChat;
-        GetField<Dictionary<Guid, string>>(vm, "_queuedBusySendPrompts")[queuedChat.Id] = "send me later";
+        QueueBusySendPrompt(vm, queuedChat.Id, "send me later");
 
         await InvokePrivateAsync(vm, "DrainQueuedBusySendAsync", queuedChat.Id);
 
-        Assert.False(GetField<Dictionary<Guid, string>>(vm, "_queuedBusySendPrompts").ContainsKey(queuedChat.Id));
+        Assert.False(GetQueuedBusySends(vm).Contains(queuedChat.Id));
         Assert.Equal("send me later", GetField<Dictionary<Guid, string>>(vm, "_chatDrafts")[queuedChat.Id]);
         Assert.Empty(queuedChat.Messages);
     }
@@ -928,28 +937,57 @@ public sealed class ChatViewModelLeakTests
             ?.GetValue(instance)
             ?? throw new InvalidOperationException($"Field {name} was not found."));
 
+    private static System.Collections.IDictionary GetQueuedBusySends(ChatViewModel vm)
+        => GetField<System.Collections.IDictionary>(vm, "_queuedBusySendPrompts");
+
+    private static object GetQueuedBusySend(ChatViewModel vm, Guid chatId)
+        => GetQueuedBusySends(vm)[chatId]
+           ?? throw new InvalidOperationException($"Queued send for {chatId} was not found.");
+
+    private static string GetQueuedBusySendPrompt(ChatViewModel vm, Guid chatId)
+        => (string)(GetQueuedBusySend(vm, chatId)
+            .GetType()
+            .GetProperty("Prompt")
+            ?.GetValue(GetQueuedBusySend(vm, chatId))
+            ?? throw new InvalidOperationException("Queued send prompt was not found."));
+
+    private static IReadOnlyList<string> GetQueuedBusySendAttachmentPaths(ChatViewModel vm, Guid chatId)
+        => (IReadOnlyList<string>)(GetQueuedBusySend(vm, chatId)
+            .GetType()
+            .GetProperty("AttachmentPaths")
+            ?.GetValue(GetQueuedBusySend(vm, chatId))
+            ?? throw new InvalidOperationException("Queued send attachment paths were not found."));
+
+    private static void QueueBusySendPrompt(ChatViewModel vm, Guid chatId, string prompt, params string[] attachmentPaths)
+    {
+        vm.GetType()
+            .GetMethod("QueueBusySendPrompt", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?.Invoke(vm, [chatId, prompt, attachmentPaths]);
+    }
+
     private static void InvokePrivate(object instance, string name, params object[] args)
     {
-        instance.GetType()
-            .GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic)
-            ?.Invoke(instance, args);
+        GetPrivateInstanceMethod(instance, name, args.Length).Invoke(instance, args);
     }
 
     private static T InvokePrivate<T>(object instance, string name, params object[] args)
-        => (T)(instance.GetType()
-            .GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic)
-            ?.Invoke(instance, args)
+        => (T)(GetPrivateInstanceMethod(instance, name, args.Length)
+            .Invoke(instance, args)
             ?? throw new InvalidOperationException($"Method {name} was not found."));
 
     private static async Task InvokePrivateAsync(object instance, string name, params object[] args)
     {
-        var task = instance.GetType()
-            .GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic)
-            ?.Invoke(instance, args) as Task
+        var task = GetPrivateInstanceMethod(instance, name, args.Length).Invoke(instance, args) as Task
             ?? throw new InvalidOperationException($"Async method {name} was not found.");
 
         await task;
     }
+
+    private static MethodInfo GetPrivateInstanceMethod(object instance, string name, int argumentCount)
+        => instance.GetType()
+               .GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)
+               .SingleOrDefault(method => method.Name == name && method.GetParameters().Length == argumentCount)
+           ?? throw new InvalidOperationException($"Method {name} with {argumentCount} parameters was not found.");
 
     private static T InvokePrivateStatic<T>(Type type, string name, params object[] args)
         => (T)(type

--- a/tests/Lumi.Tests/RebaseAttachmentPathsTests.cs
+++ b/tests/Lumi.Tests/RebaseAttachmentPathsTests.cs
@@ -162,4 +162,26 @@ public class RebaseAttachmentPathsTests
         Assert.Equal(@"E:\Git\Lumi-wt-abc123\docs", msg.Attachments[0]);
         Assert.Equal("docs", directory.DisplayName);
     }
+
+    [Fact]
+    public void Chat_message_attachment_paths_include_files_and_directories()
+    {
+        var attachments = new List<UserMessageAttachment>
+        {
+            new UserMessageAttachmentFile
+            {
+                Path = @"E:\Git\Lumi\notes.txt",
+                DisplayName = "notes.txt"
+            },
+            new UserMessageAttachmentDirectory
+            {
+                Path = @"E:\Git\Lumi\docs",
+                DisplayName = "docs"
+            }
+        };
+
+        var paths = ChatViewModel.GetChatMessageAttachmentPaths(attachments);
+
+        Assert.Equal([@"E:\Git\Lumi\notes.txt", @"E:\Git\Lumi\docs"], paths);
+    }
 }

--- a/tests/Lumi.Tests/RebaseAttachmentPathsTests.cs
+++ b/tests/Lumi.Tests/RebaseAttachmentPathsTests.cs
@@ -132,4 +132,34 @@ public class RebaseAttachmentPathsTests
 
         Assert.Equal("file.cs", FileAt(attachments, 0).DisplayName);
     }
+
+    [Fact]
+    public void Rebases_directory_attachments()
+    {
+        var attachments = new List<UserMessageAttachment>
+        {
+            new UserMessageAttachmentDirectory
+            {
+                Path = @"E:\Git\Lumi\docs",
+                DisplayName = "docs"
+            }
+        };
+        var msg = new ChatMessage
+        {
+            Role = "user",
+            Content = "test",
+            Attachments = [@"E:\Git\Lumi\docs"]
+        };
+
+        ChatViewModel.RebaseAttachmentPaths(
+            attachments,
+            msg,
+            @"E:\Git\Lumi",
+            @"E:\Git\Lumi-wt-abc123");
+
+        var directory = Assert.IsType<UserMessageAttachmentDirectory>(attachments[0]);
+        Assert.Equal(@"E:\Git\Lumi-wt-abc123\docs", directory.Path);
+        Assert.Equal(@"E:\Git\Lumi-wt-abc123\docs", msg.Attachments[0]);
+        Assert.Equal("docs", directory.DisplayName);
+    }
 }


### PR DESCRIPTION
This pull request introduces significant improvements to how file and directory attachments are handled in the chat workflow, enhancing validation, error reporting, and draft persistence. The changes ensure that attachments are properly validated before sending, errors are surfaced to the user, and both prompts and attachments are preserved as drafts per chat. Additionally, the code introduces a new service for attachment preparation and streamlines the management of attachment-related UI state.

**Key changes include:**

### Attachment Validation and Preparation

- Introduced the `AttachmentPreparationService` (`src/Lumi/Services/AttachmentPreparationService.cs`) to encapsulate logic for validating and preparing file and directory attachments, including error handling for invalid paths and distinguishing between files and directories.
- All attachments are now validated before being added or sent; invalid attachments are marked as failed and surfaced to the user with error messages. ([src/Lumi/ViewModels/ChatViewModel.Context.csL396-R412](diffhunk://#diff-abef38ebfc0d18ade76b178c96a590c159bfb3366ecf9da0eb3f5a563eb94b85L396-R412), F54cc2d8L1510R132)

### Attachment Draft and State Management

- Drafts now persist both the prompt text and associated attachment paths per chat, including across chat switches and clear actions, using new methods (`SaveChatDraft`, `RestoreComposerDraft`, etc.) and an additional dictionary for attachment paths. (F54cc2d8L1510R132, [[1]](diffhunk://#diff-4883f38d0cea57a5f647351a095fde44fb4de97ee1d7974dadc57649ad81b5b8L909-R913) [[2]](diffhunk://#diff-4883f38d0cea57a5f647351a095fde44fb4de97ee1d7974dadc57649ad81b5b8L974-R972) [[3]](diffhunk://#diff-4883f38d0cea57a5f647351a095fde44fb4de97ee1d7974dadc57649ad81b5b8L1152-R1149) [[4]](diffhunk://#diff-4883f38d0cea57a5f647351a095fde44fb4de97ee1d7974dadc57649ad81b5b8L1205-R1197)
- The logic for queuing and draining prompts when a chat is busy has been updated to include attachment paths, ensuring both prompt and attachments are restored and sent together. ([src/Lumi/ViewModels/ChatViewModel.ChatStateCleanup.csL15-R44](diffhunk://#diff-e8b64d4f616c6e5a53be31bee192ba51bc375a7917d0f2ca89a41f22639098eaL15-R44), F54cc2d8L1510R132)

### UI State and Error Reporting

- Added observable properties and event handlers to surface attachment errors in the UI, including `PendingAttachmentErrorText` and `HasPendingAttachmentError`, and logic to update these when attachment items change. [[1]](diffhunk://#diff-ce2a20c0b77da3deb8c90607ccaf43fa5edc2be53ca406519ca2785dda8c5fd2R101-R107) [[2]](diffhunk://#diff-ce2a20c0b77da3deb8c90607ccaf43fa5edc2be53ca406519ca2785dda8c5fd2R301) [[3]](diffhunk://#diff-ce2a20c0b77da3deb8c90607ccaf43fa5edc2be53ca406519ca2785dda8c5fd2R770-R787)
- The UI now distinguishes between sendable and failed attachments, and provides user feedback when attachments are invalid. [[1]](diffhunk://#diff-abef38ebfc0d18ade76b178c96a590c159bfb3366ecf9da0eb3f5a563eb94b85L396-R412) [[2]](diffhunk://#diff-ce2a20c0b77da3deb8c90607ccaf43fa5edc2be53ca406519ca2785dda8c5fd2R770-R787)

### Attachment Path Handling

- Improved logic for rebasing both file and directory attachment paths when the working directory changes, ensuring paths remain valid for the Copilot service.
- Provided helper methods for extracting attachment paths and preparing SDK attachment objects for sending. ([src/Lumi/ViewModels/ChatViewModel.Context.csL485-R501](diffhunk://#diff-abef38ebfc0d18ade76b178c96a590c159bfb3366ecf9da0eb3f5a563eb94b85L485-R501), F54cc2d8L1510R132)

### Code Structure and Cleanliness

- Refactored and removed obsolete methods for attachment conversion, centralizing validation and preparation logic in the new service and related helpers. ([src/Lumi/ViewModels/ChatViewModel.Context.csL485-R501](diffhunk://#diff-abef38ebfc0d18ade76b178c96a590c159bfb3366ecf9da0eb3f5a563eb94b85L485-R501), F54cc2d8L1510R132)

These changes collectively improve reliability, user experience, and maintainability of attachment handling in the chat feature.