### PR TITLE
Add PR validation workflow

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,49 @@
+name: PR Build
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: preview
+
+      - name: Restore
+        run: dotnet restore Lumi.slnx
+
+      - name: Build
+        run: dotnet build Lumi.slnx --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test Lumi.slnx --configuration Release --no-build --logger "trx;LogFileName=test-results.trx" --results-directory TestResults
+
+      - name: Upload test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: TestResults
+          if-no-files-found: ignore

--- a/tests/Lumi.Tests/BackgroundJobScheduleTests.cs
+++ b/tests/Lumi.Tests/BackgroundJobScheduleTests.cs
@@ -65,7 +65,7 @@ public sealed class BackgroundJobScheduleTests
     [Fact]
     public void ComputeNextRun_Monthly_ClampsShortMonths()
     {
-        var now = new DateTimeOffset(2026, 1, 31, 9, 0, 0, TimeSpan.FromHours(2));
+        var now = CreateLocalDateTimeOffset(2026, 1, 31, 9, 0, 0);
         var job = new BackgroundJob
         {
             TriggerType = BackgroundJobTriggerTypes.Time,
@@ -74,7 +74,7 @@ public sealed class BackgroundJobScheduleTests
             DailyTime = "08:00"
         };
 
-        var expected = new DateTimeOffset(2026, 2, 28, 8, 0, 0, TimeSpan.FromHours(2));
+        var expected = CreateLocalDateTimeOffset(2026, 2, 28, 8, 0, 0);
         Assert.Equal(expected, BackgroundJobSchedule.ComputeNextRun(job, now, afterRun: false));
     }
 
@@ -118,5 +118,17 @@ public sealed class BackgroundJobScheduleTests
         var now = new DateTimeOffset(2026, 4, 26, 10, 0, 0, TimeSpan.FromHours(3));
 
         Assert.Equal(TimeSpan.FromHours(24), BackgroundJobService.GetSchedulerDelay(now.AddDays(7), now));
+    }
+
+    private static DateTimeOffset CreateLocalDateTimeOffset(
+        int year,
+        int month,
+        int day,
+        int hour,
+        int minute,
+        int second)
+    {
+        var localDateTime = new DateTime(year, month, day, hour, minute, second);
+        return new DateTimeOffset(localDateTime, TimeZoneInfo.Local.GetUtcOffset(localDateTime));
     }
 }


### PR DESCRIPTION
Adds a classic PR build workflow for Lumi.

Validation gates:
- restore `Lumi.slnx`
- build `Lumi.slnx` in Release
- test `Lumi.slnx` in Release
- upload TRX test results

The workflow is intentionally PR-only, with manual dispatch available for debugging.