### PR TITLE
Add multi-window tray session support

### DIFF
--- a/src/Lumi/App.axaml.cs
+++ b/src/Lumi/App.axaml.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
@@ -16,8 +18,14 @@ namespace Lumi;
 public partial class App : Application
 {
     private TrayIcon? _trayIcon;
-    private Window? _mainWindow;
+    private MainWindow? _mainWindow;
     private GlobalHotkeyService? _hotkeyService;
+    private DataStore? _dataStore;
+    private CopilotService? _copilotService;
+    private UpdateService? _updateService;
+    private BackgroundJobService? _backgroundJobService;
+    private readonly List<MainWindow> _windows = [];
+    private int _secondaryWindowSequence;
 
     public override void Initialize()
     {
@@ -29,22 +37,24 @@ public partial class App : Application
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             var dataStore = new DataStore();
+            _dataStore = dataStore;
 
             // Initialize localization before creating any UI
             Loc.Load(dataStore.Data.Settings.Language);
 
             var copilotService = new CopilotService();
+            _copilotService = copilotService;
             var updateService = new UpdateService();
+            _updateService = updateService;
             updateService.Initialize();
-            var vm = new MainViewModel(
-                dataStore,
-                copilotService,
-                updateService,
-                Program.ForceOnboarding
+            var vm = CreateMainViewModel(
+                forceOnboarding: Program.ForceOnboarding,
+                startBackgroundJobs: true
 #if DEBUG
-                , Program.OpenAgentDebugHarness
+                , openAgentDebugHarness: Program.OpenAgentDebugHarness
 #endif
             );
+            _backgroundJobService = vm.BackgroundJobService;
 
             // Save data and dispose CopilotService on app shutdown.
             // The window is already hidden at this point so nothing blocks the user.
@@ -53,7 +63,17 @@ public partial class App : Application
             desktop.ShutdownRequested += (_, _) =>
             {
                 updateService.Dispose();
-                vm.Dispose();
+                var viewModels = _windows
+                    .Select(static window => window.DataContext)
+                    .OfType<MainViewModel>();
+                if (_mainWindow?.DataContext is MainViewModel primaryVm)
+                    viewModels = viewModels.Append(primaryVm);
+
+                foreach (var windowVm in viewModels.Distinct())
+                {
+                    windowVm.Dispose();
+                }
+
                 Task.Run(async () =>
                 {
                     try
@@ -79,7 +99,7 @@ public partial class App : Application
             // Apply saved density
             MainWindow.ApplyDensityStatic(dataStore.Data.Settings.IsCompactDensity);
 
-            var window = new MainWindow { DataContext = vm };
+            var window = CreateWindow(vm, isPrimary: true);
             _mainWindow = window;
 
             // Apply RTL for right-to-left languages
@@ -123,6 +143,54 @@ public partial class App : Application
         base.OnFrameworkInitializationCompleted();
     }
 
+    private MainViewModel CreateMainViewModel(
+        bool forceOnboarding = false,
+        bool startBackgroundJobs = false
+#if DEBUG
+        , bool openAgentDebugHarness = false
+#endif
+        )
+    {
+        if (_dataStore is null || _copilotService is null || _updateService is null)
+            throw new InvalidOperationException("Lumi services are not initialized.");
+
+        // Secondary windows share the primary scheduler so background jobs have a single runner.
+        return new MainViewModel(
+            _dataStore,
+            _copilotService,
+            _updateService,
+            forceOnboarding,
+            _backgroundJobService,
+            startBackgroundJobs
+#if DEBUG
+            , openAgentDebugHarness
+#endif
+        );
+    }
+
+    private MainWindow CreateWindow(MainViewModel vm, bool isPrimary)
+    {
+        var window = new MainWindow
+        {
+            DataContext = vm,
+            IsPrimaryWindow = isPrimary,
+            SecondaryWindowCascadeIndex = isPrimary ? 0 : ++_secondaryWindowSequence
+        };
+
+        if (Loc.IsRightToLeft)
+            window.FlowDirection = Avalonia.Media.FlowDirection.RightToLeft;
+
+        window.Closed += (_, _) =>
+        {
+            _windows.Remove(window);
+            if (!isPrimary && window.DataContext is MainViewModel windowVm)
+                windowVm.Dispose();
+        };
+
+        _windows.Add(window);
+        return window;
+    }
+
     private void OnGlobalHotkeyPressed()
     {
         Dispatcher.UIThread.Post(ToggleMainWindow);
@@ -139,6 +207,9 @@ public partial class App : Application
             var showItem = new NativeMenuItem(Loc.Tray_Show);
             showItem.Click += (_, _) => ShowMainWindow();
 
+            var newWindowItem = new NativeMenuItem(Loc.Tray_NewWindow);
+            newWindowItem.Click += (_, _) => OpenNewWindow();
+
             var exitItem = new NativeMenuItem(Loc.Tray_Exit);
             exitItem.Click += (_, _) =>
             {
@@ -148,6 +219,7 @@ public partial class App : Application
 
             var menu = new NativeMenu();
             menu.Items.Add(showItem);
+            menu.Items.Add(newWindowItem);
             menu.Items.Add(new NativeMenuItemSeparator());
             menu.Items.Add(exitItem);
 
@@ -190,6 +262,26 @@ public partial class App : Application
             Avalonia.Threading.Dispatcher.UIThread.Post(() => chatView?.FocusComposer(),
                 Avalonia.Threading.DispatcherPriority.Input);
         }
+    }
+
+    public void OpenNewWindow(Guid? chatId = null)
+    {
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            Dispatcher.UIThread.Post(() => OpenNewWindow(chatId));
+            return;
+        }
+
+        var window = CreateWindow(CreateMainViewModel(), isPrimary: false);
+        if (_mainWindow is { IsVisible: true } owner)
+            window.SecondaryWindowAnchorPosition = owner.Position;
+
+        window.Show();
+
+        window.Activate();
+
+        if (chatId is Guid targetChatId && window.DataContext is MainViewModel vm)
+            _ = vm.OpenChatByIdAsync(targetChatId);
     }
 
     public void ShowMainWindow(Guid? chatId)

--- a/src/Lumi/Resources/Strings/en.json
+++ b/src/Lumi/Resources/Strings/en.json
@@ -81,6 +81,7 @@
 
   "Sidebar_NewChat": "New Chat",
   "Sidebar_NewChatTooltip": "New chat (Ctrl+N)",
+  "Sidebar_NewWindowTooltip": "Open a new Lumi window",
   "Sidebar_Search": "Search (Ctrl+K)",
   "Sidebar_Search_Short": "Search…",
   "Sidebar_Jobs": "Background Jobs",
@@ -98,6 +99,7 @@
   "Sidebar_All": "All",
 
   "Menu_Rename": "Rename",
+  "Menu_OpenInNewWindow": "Open in New Window",
   "Menu_MoveToProject": "Move to Project",
   "Menu_RemoveFromProject": "Remove from Project",
   "Menu_Delete": "Delete",
@@ -551,6 +553,7 @@
   "Button_ResetDefaults": "Reset Defaults",
 
   "Tray_Show": "Show Lumi",
+  "Tray_NewWindow": "New Window",
   "Tray_Exit": "Exit",
 
   "Notification_ResponseReady": "Response ready",

--- a/src/Lumi/Resources/Strings/he.json
+++ b/src/Lumi/Resources/Strings/he.json
@@ -81,6 +81,7 @@
 
   "Sidebar_NewChat": "צ׳אט חדש",
   "Sidebar_NewChatTooltip": "צ׳אט חדש (Ctrl+N)",
+  "Sidebar_NewWindowTooltip": "פתיחת חלון לומי חדש",
   "Sidebar_Search": "חיפוש (Ctrl+K)",
   "Sidebar_Search_Short": "חיפוש…",
   "Sidebar_Jobs": "משימות רקע",
@@ -98,6 +99,7 @@
   "Sidebar_All": "הכול",
 
   "Menu_Rename": "שינוי שם",
+  "Menu_OpenInNewWindow": "פתיחה בחלון חדש",
   "Menu_MoveToProject": "העברה לפרויקט",
   "Menu_RemoveFromProject": "הסרה מפרויקט",
   "Menu_Delete": "מחיקה",
@@ -552,6 +554,7 @@
   "Button_ResetDefaults": "איפוס ברירות מחדל",
 
   "Tray_Show": "הצגת לומי",
+  "Tray_NewWindow": "חלון חדש",
   "Tray_Exit": "יציאה",
 
   "Notification_ResponseReady": "התגובה מוכנה",

--- a/src/Lumi/ViewModels/ChatViewModel.ChatStateCleanup.cs
+++ b/src/Lumi/ViewModels/ChatViewModel.ChatStateCleanup.cs
@@ -7,6 +7,52 @@ namespace Lumi.ViewModels;
 
 public partial class ChatViewModel
 {
+    private bool _isDisposed;
+
+    public void Dispose()
+    {
+        if (_isDisposed)
+            return;
+
+        _isDisposed = true;
+        _copilotService.Reconnected -= OnCopilotReconnected;
+        _copilotService.SessionDeletedRemotely -= OnSessionDeletedRemotely;
+        _transcriptWindow.PropertyChanged -= OnTranscriptWindowPropertyChanged;
+
+        lock (_chatLoadSync)
+        {
+            _chatLoadRequestId++;
+            try { _chatLoadCts?.Cancel(); }
+            catch (ObjectDisposedException) { }
+            _chatLoadCts?.Dispose();
+            _chatLoadCts = null;
+        }
+
+        foreach (var chatId in _sessionCache.Keys
+                     .Concat(_ctsSources.Keys)
+                     .Concat(_runtimeStates.Keys)
+                     .Distinct()
+                     .ToList())
+        {
+            ReleaseSessionResources(chatId, cancelActiveRequest: true, deleteServerSession: false);
+            RemoveSuggestionTracking(chatId);
+            DisposeBrowserService(chatId);
+            _dataStore.RemoveChatLoadLock(chatId);
+        }
+
+        _runtimeStates.Clear();
+        _inProgressMessages.Clear();
+        _modelSelectionSaveCts?.Cancel();
+        _modelSelectionSaveCts?.Dispose();
+        _modelSelectionSaveCts = null;
+        _modelSelectionSyncCts?.Cancel();
+        _modelSelectionSyncCts?.Dispose();
+        _modelSelectionSyncCts = null;
+        _fileSearchCts?.Cancel();
+        _fileSearchCts?.Dispose();
+        _fileSearchCts = null;
+    }
+
     private bool IsChatRuntimeActive(Guid chatId)
         => _runtimeStates.TryGetValue(chatId, out var runtime)
            && (runtime.IsBusy || runtime.IsStreaming || runtime.HasPendingBackgroundWork

--- a/src/Lumi/ViewModels/ChatViewModel.cs
+++ b/src/Lumi/ViewModels/ChatViewModel.cs
@@ -23,7 +23,7 @@ using ChatMessage = Lumi.Models.ChatMessage;
 
 namespace Lumi.ViewModels;
 
-public partial class ChatViewModel : ObservableObject
+public partial class ChatViewModel : ObservableObject, IDisposable
 {
     private const int SuggestionHistoryScanLimit = 1000;
     private const int SuggestionHistorySummaryMaxItems = 24;

--- a/src/Lumi/ViewModels/MainViewModel.cs
+++ b/src/Lumi/ViewModels/MainViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
@@ -26,6 +27,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// <summary>A dedicated BrowserService for Settings cookie import/clear (not tied to any chat).</summary>
     private readonly BrowserService _settingsBrowserService;
     private readonly BackgroundJobService _backgroundJobService;
+    private readonly bool _ownsBackgroundJobService;
+    private readonly HashSet<Chat> _runningStateSubscriptions = [];
+    private bool _isDisposed;
     private bool _isRefreshingCopilotState;
     private bool _isSyncingDefaultModelSelectionFromChat;
     private readonly ChatNavigationHistory _chatNavigationHistory = new();
@@ -129,7 +133,9 @@ public partial class MainViewModel : ObservableObject, IDisposable
         DataStore dataStore,
         CopilotService copilotService,
         UpdateService updateService,
-        bool forceOnboarding = false
+        bool forceOnboarding = false,
+        BackgroundJobService? backgroundJobService = null,
+        bool startBackgroundJobs = true
 #if DEBUG
         , bool openAgentDebugHarness = false
 #endif
@@ -167,7 +173,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         OnboardingVM.ThemeChanged += isDark => IsDarkTheme = isDark;
 
         ChatVM = new ChatViewModel(dataStore, copilotService);
-        _backgroundJobService = new BackgroundJobService(dataStore, ChatVM);
+        _backgroundJobService = backgroundJobService ?? new BackgroundJobService(dataStore, ChatVM);
+        _ownsBackgroundJobService = backgroundJobService is null;
         JobsVM = new BackgroundJobsViewModel(dataStore, _backgroundJobService);
         SkillsVM = new SkillsViewModel(dataStore);
         AgentsVM = new AgentsViewModel(dataStore);
@@ -257,10 +264,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             RefreshFeatureManagementUi();
         };
         JobsVM.OpenChatRequested += jobChatId => _ = OpenChatByIdAsync(jobChatId);
-        _backgroundJobService.JobsChanged += () =>
-        {
-            Dispatcher.UIThread.Post(RefreshFeatureManagementUi);
-        };
+        _backgroundJobService.JobsChanged += OnBackgroundJobServiceJobsChanged;
 
         SettingsVM.SettingsChanged += () =>
         {
@@ -316,7 +320,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         SubscribeChatRunningState();
         RefreshChatList();
         ChatVM.RefreshComposerCatalogs();
-        _backgroundJobService.Start();
+        if (_ownsBackgroundJobService && startBackgroundJobs)
+            _backgroundJobService.Start();
 
 #if DEBUG
         if (openAgentDebugHarness)
@@ -334,7 +339,17 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
     public void Dispose()
     {
-        _backgroundJobService.Dispose();
+        if (_isDisposed)
+            return;
+
+        _isDisposed = true;
+        _backgroundJobService.JobsChanged -= OnBackgroundJobServiceJobsChanged;
+        UnsubscribeChatRunningState();
+        if (_ownsBackgroundJobService)
+            _backgroundJobService.Dispose();
+        ChatVM.Dispose();
+        SettingsVM.Dispose();
+        _ = _settingsBrowserService.DisposeAsync();
     }
 
     private async Task RefreshCopilotStateAsync(bool refreshAuthStatus)
@@ -423,15 +438,42 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
     private void SubscribeChatRunningState()
     {
-        foreach (var chat in _dataStore.Data.Chats)
+        var currentChats = _dataStore.Data.Chats.ToHashSet();
+        foreach (var chat in _runningStateSubscriptions.Where(chat => !currentChats.Contains(chat)).ToList())
         {
             chat.PropertyChanged -= OnChatRunningChanged;
-            chat.PropertyChanged += OnChatRunningChanged;
+            _runningStateSubscriptions.Remove(chat);
         }
+
+        foreach (var chat in _dataStore.Data.Chats)
+        {
+            if (_runningStateSubscriptions.Add(chat))
+                chat.PropertyChanged += OnChatRunningChanged;
+        }
+    }
+
+    private void UnsubscribeChatRunningState()
+    {
+        foreach (var chat in _runningStateSubscriptions)
+            chat.PropertyChanged -= OnChatRunningChanged;
+
+        _runningStateSubscriptions.Clear();
+    }
+
+    private void OnBackgroundJobServiceJobsChanged()
+    {
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (!_isDisposed)
+                RefreshFeatureManagementUi();
+        });
     }
 
     private void OnChatRunningChanged(object? sender, PropertyChangedEventArgs e)
     {
+        if (_isDisposed)
+            return;
+
         if (e.PropertyName == nameof(Chat.IsRunning))
             RefreshProjectRunningState();
     }
@@ -593,6 +635,23 @@ public partial class MainViewModel : ObservableObject, IDisposable
         // Auto-assign the active project filter to new chats
         SetDraftChatProjectContext(SelectedProjectFilter);
         SelectedNavIndex = 0;
+    }
+
+    [RelayCommand]
+    private void OpenNewWindow()
+    {
+        if (Avalonia.Application.Current is App app)
+            app.OpenNewWindow();
+    }
+
+    [RelayCommand]
+    private void OpenChatInNewWindow(Chat? chat)
+    {
+        if (chat is null)
+            return;
+
+        if (Avalonia.Application.Current is App app)
+            app.OpenNewWindow(chat.Id);
     }
 
     [RelayCommand]

--- a/src/Lumi/ViewModels/SettingsViewModel.cs
+++ b/src/Lumi/ViewModels/SettingsViewModel.cs
@@ -10,7 +10,7 @@ using Lumi.Services;
 
 namespace Lumi.ViewModels;
 
-public partial class SettingsViewModel : ObservableObject
+public partial class SettingsViewModel : ObservableObject, IDisposable
 {
     public const int AboutPageIndex = 6;
 
@@ -347,6 +347,11 @@ public partial class SettingsViewModel : ObservableObject
         // Wire update status changes
         _updateService.StatusChanged += OnUpdateStatusChanged;
         OnUpdateStatusChanged(_updateService.CurrentStatus);
+    }
+
+    public void Dispose()
+    {
+        _updateService.StatusChanged -= OnUpdateStatusChanged;
     }
 
     private void OnUpdateStatusChanged(UpdateStatus status)

--- a/src/Lumi/Views/MainWindow.axaml
+++ b/src/Lumi/Views/MainWindow.axaml
@@ -28,6 +28,7 @@
     <StreamGeometry x:Key="Icon.Compose">M15.2 3.8a2.4 2.4 0 0 1 3.4 0l1.6 1.6a2.4 2.4 0 0 1 0 3.4L9 20l-5 1 1-5L15.2 3.8z</StreamGeometry>
     <StreamGeometry x:Key="Icon.Search">M10 3a7 7 0 1 0 4.2 12.6l4.1 4.1a1 1 0 0 0 1.4-1.4l-4.1-4.1A7 7 0 0 0 10 3zm-5 7a5 5 0 1 1 10 0 5 5 0 0 1-10 0z</StreamGeometry>
     <StreamGeometry x:Key="Icon.Plus">M12 4a1 1 0 0 1 1 1v6h6a1 1 0 1 1 0 2h-6v6a1 1 0 1 1-2 0v-6H5a1 1 0 1 1 0-2h6V5a1 1 0 0 1 1-1z</StreamGeometry>
+    <StreamGeometry x:Key="Icon.Window">M4 5h11a2 2 0 0 1 2 2v1h1a2 2 0 0 1 2 2v9H7a2 2 0 0 1-2-2v-1H3V7a2 2 0 0 1 2-2zm1 2v7h10V7H5zm2 3v7h11v-7H7z</StreamGeometry>
     <StreamGeometry x:Key="Icon.Trash">M9 3h6a1 1 0 0 1 1 1H7a1 1 0 0 1 1-1zM4 6h16v1H4V6zm2 2h12l-1 13H7L6 8zm4 2v8h1v-8h-1zm3 0v8h1v-8h-1z</StreamGeometry>
     <StreamGeometry x:Key="Icon.Memory">M9.5 2A1.5 1.5 0 0 0 8 3.5V4H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2h-4v-.5A1.5 1.5 0 0 0 14.5 2h-5zM10 4V3.5a.5.5 0 0 1 .5-.5h3a.5.5 0 0 1 .5.5V4h-4zm-2 5a1 1 0 1 1 2 0 1 1 0 0 1-2 0zm5 0a1 1 0 1 1 2 0 1 1 0 0 1-2 0zm-5 4a1 1 0 1 1 2 0 1 1 0 0 1-2 0zm5 0a1 1 0 1 1 2 0 1 1 0 0 1-2 0z</StreamGeometry>
     <StreamGeometry x:Key="Icon.Plug">M17 6.1h3V8h-3v2.1a5 5 0 0 1-4 4.9V18h2v2H9v-2h2v-3a5 5 0 0 1-4-4.9V8H4V6.1h3V4h2v2.1h4V4h2v2.1zM9 8v2.1a3 3 0 0 0 6 0V8H9z</StreamGeometry>
@@ -452,11 +453,24 @@
           <!-- ── 0: Chat sidebar ── -->
           <Panel x:Name="SidebarChat">
             <DockPanel>
-              <Border DockPanel.Dock="Top" Margin="16,8,16,0">
+              <DockPanel DockPanel.Dock="Top" Margin="16,8,16,0" LastChildFill="True">
+                <Button DockPanel.Dock="Right"
+                        x:Name="NewWindowButton"
+                        Classes="subtle"
+                        Padding="8"
+                        MinHeight="0"
+                        MinWidth="0"
+                        CornerRadius="{DynamicResource Radius.Base}"
+                        ToolTip.Tip="{loc:Str Sidebar_NewWindowTooltip}"
+                        Command="{Binding OpenNewWindowCommand}">
+                  <PathIcon Data="{StaticResource Icon.Window}" Width="14" Height="14"
+                            Foreground="{DynamicResource Brush.TextSecondary}" />
+                </Button>
                 <Button Classes="subtle" HorizontalAlignment="Stretch"
                         HorizontalContentAlignment="Left"
                         CornerRadius="{DynamicResource Radius.Base}"
                         Padding="10,8" MinHeight="0"
+                        Margin="0,0,6,0"
                         ToolTip.Tip="{loc:Str Sidebar_NewChatTooltip}"
                         Command="{Binding NewChatCommand}"
                         Click="NewChatButton_Click">
@@ -468,7 +482,7 @@
                                VerticalAlignment="Center" />
                   </StackPanel>
                 </Button>
-              </Border>
+              </DockPanel>
               <!-- ── Project lens: compact selector that scales to many projects ── -->
               <Border x:Name="ProjectSwitcherRoot"
                       DockPanel.Dock="Top"
@@ -573,6 +587,14 @@
                                               CommandParameter="{Binding}">
                                       <MenuItem.Icon>
                                         <PathIcon Data="{StaticResource Icon.Rename}" Width="14" Height="14" />
+                                      </MenuItem.Icon>
+                                    </MenuItem>
+                                    <MenuItem x:Name="OpenChatInNewWindowMenuItem"
+                                              Header="{loc:Str Menu_OpenInNewWindow}"
+                                              Command="{Binding $parent[Window].DataContext.OpenChatInNewWindowCommand}"
+                                              CommandParameter="{Binding}">
+                                      <MenuItem.Icon>
+                                        <PathIcon Data="{StaticResource Icon.Window}" Width="14" Height="14" />
                                       </MenuItem.Icon>
                                     </MenuItem>
                                     <MenuItem x:Name="MoveToProjectMenu" Header="{loc:Str Menu_MoveToProject}">

--- a/src/Lumi/Views/MainWindow.axaml.cs
+++ b/src/Lumi/Views/MainWindow.axaml.cs
@@ -113,6 +113,10 @@ public partial class MainWindow : Window
     private MainViewModel? _wiredVm;
     private const int NavHoverIntentDelayMs = 85;
 
+    public bool IsPrimaryWindow { get; set; } = true;
+    public int SecondaryWindowCascadeIndex { get; set; }
+    public PixelPoint? SecondaryWindowAnchorPosition { get; set; }
+
     public MainWindow()
     {
         InitializeComponent();
@@ -149,7 +153,10 @@ public partial class MainWindow : Window
 
         Opened += (_, _) =>
         {
-            RestoreWindowBounds();
+            if (IsPrimaryWindow)
+                RestoreWindowBounds();
+            else
+                PlaceSecondaryWindow();
             UpdateTransparencyFallbackOpacity();
             ApplyWindowContentPaddingForState();
         };
@@ -369,7 +376,7 @@ public partial class MainWindow : Window
     protected override void OnClosing(WindowClosingEventArgs e)
     {
         // If tray behavior is enabled, hide instead of closing.
-        if (DataContext is MainViewModel vm && vm.SettingsVM.MinimizeToTray)
+        if (IsPrimaryWindow && DataContext is MainViewModel vm && vm.SettingsVM.MinimizeToTray)
         {
             e.Cancel = true;
             HideToTray();
@@ -464,12 +471,73 @@ public partial class MainWindow : Window
             WindowState = WindowState.Maximized;
     }
 
+    private void PlaceSecondaryWindow()
+    {
+        if (DataContext is not MainViewModel vm) return;
+        var settings = vm.DataStore.Data.Settings;
+
+        const double defaultWidth = 1320;
+        const double defaultHeight = 860;
+        const int cascadeStep = 28;
+        const int maxCascadeSteps = 8;
+
+        var screen = (SecondaryWindowAnchorPosition is { } anchor ? Screens.ScreenFromPoint(anchor) : null)
+            ?? (Owner is Window owner ? Screens.ScreenFromWindow(owner) : null)
+            ?? Screens.ScreenFromWindow(this)
+            ?? Screens.Primary;
+        if (screen is null)
+        {
+            Width = settings.WindowWidth ?? defaultWidth;
+            Height = settings.WindowHeight ?? defaultHeight;
+            WindowStartupLocation = WindowStartupLocation.CenterScreen;
+            return;
+        }
+
+        var scaling = screen.Scaling <= 0 ? 1.0 : screen.Scaling;
+        var workArea = screen.WorkingArea;
+        var maxW = Math.Max(1.0, workArea.Width / scaling);
+        var maxH = Math.Max(1.0, workArea.Height / scaling);
+        var width = Math.Clamp(settings.WindowWidth ?? defaultWidth, Math.Min(MinWidth, maxW), maxW);
+        var height = Math.Clamp(settings.WindowHeight ?? defaultHeight, Math.Min(MinHeight, maxH), maxH);
+        Width = width;
+        Height = height;
+
+        var offset = cascadeStep * Math.Max(1, SecondaryWindowCascadeIndex % maxCascadeSteps);
+        int left;
+        int top;
+
+        if (SecondaryWindowAnchorPosition is { } anchorPosition)
+        {
+            left = anchorPosition.X + (int)(offset * scaling);
+            top = anchorPosition.Y + (int)(offset * scaling);
+        }
+        else if (Owner is Window { IsVisible: true } ownerWindow)
+        {
+            left = ownerWindow.Position.X + (int)(offset * scaling);
+            top = ownerWindow.Position.Y + (int)(offset * scaling);
+        }
+        else
+        {
+            left = workArea.X + (workArea.Width - (int)(width * scaling)) / 2 + (int)(offset * scaling);
+            top = workArea.Y + (workArea.Height - (int)(height * scaling)) / 2 + (int)(offset * scaling);
+        }
+
+        var maxLeft = workArea.Right - (int)Math.Min(width * scaling, workArea.Width);
+        var maxTop = workArea.Bottom - (int)Math.Min(height * scaling, workArea.Height);
+        Position = new PixelPoint(
+            Math.Clamp(left, workArea.X, Math.Max(workArea.X, maxLeft)),
+            Math.Clamp(top, workArea.Y, Math.Max(workArea.Y, maxTop)));
+    }
+
     /// <summary>
     /// Captures current window bounds into settings without persisting to disk.
     /// Must be called on the UI thread while the window is still visible.
     /// </summary>
     private void CaptureBoundsToSettings()
     {
+        if (!IsPrimaryWindow)
+            return;
+
         if (DataContext is not MainViewModel vm) return;
         var settings = vm.DataStore.Data.Settings;
 
@@ -526,12 +594,15 @@ public partial class MainWindow : Window
         if (_sidebarBorder is not null)
             _sidebarBorder.Width = clampedWidth;
 
-        if (DataContext is MainViewModel vm)
+        if (IsPrimaryWindow && DataContext is MainViewModel vm)
             vm.DataStore.Data.Settings.SidebarWidth = clampedWidth;
     }
 
     private void PersistSidebarWidth()
     {
+        if (!IsPrimaryWindow)
+            return;
+
         if (DataContext is not MainViewModel vm)
             return;
 


### PR DESCRIPTION
## Summary
- Restore the retained primary Lumi window/session when the tray icon is activated.
- Add **New Window** entry points in the tray menu and chat sidebar.
- Add a conversation-list context menu action to open a specific chat in an independent secondary window.
- Keep secondary windows independent from tray/minimize persistence and clean up their subscriptions on close.

## Validation
- Built `src\Lumi\Lumi.csproj` against the project's real `net11.0-windows10.0.22621.0` target using a local .NET 11 SDK.
- Live Avalonia MCP QA covered the sidebar **New Window** button, conversation context menu, cascaded secondary windows, and binding-error checks.

## Notes
Secondary windows intentionally share the primary background-job scheduler so Lumi never starts multiple competing job runners.