### PR TITLE
Use full composer for edited chat messages

### DIFF
--- a/src/Lumi/Models/Models.cs
+++ b/src/Lumi/Models/Models.cs
@@ -24,6 +24,12 @@ public class ChatMessage
     public bool? QuestionAllowMultiSelect { get; set; }
     public bool IsStreaming { get; set; }
     public string? Model { get; set; }
+    public string? ReasoningEffort { get; set; }
+    public Guid? AgentId { get; set; }
+    public string? SdkAgentName { get; set; }
+    public bool HasAgentSelection { get; set; }
+    public List<string> ActiveMcpServerNames { get; set; } = [];
+    public bool HasMcpSelection { get; set; }
     public List<string> Attachments { get; set; } = [];
     public List<SearchSource> Sources { get; set; } = [];
     public List<SkillReference> ActiveSkills { get; set; } = [];

--- a/src/Lumi/Resources/Strings/en.json
+++ b/src/Lumi/Resources/Strings/en.json
@@ -117,6 +117,8 @@
   "Chat_SuggestionB": "Research a topic",
   "Chat_SuggestionC": "Create a document",
   "Chat_AvatarLetter": "L",
+  "Chat_EditPlaceholder": "Edit your message...",
+  "Chat_EditStatus": "Editing message - adjust text, attachments, agent, model, or MCPs, then send.",
 
   "Editor_Lumi": "Lumi Editor",
   "Editor_Project": "Project Editor",

--- a/src/Lumi/Resources/Strings/he.json
+++ b/src/Lumi/Resources/Strings/he.json
@@ -117,6 +117,8 @@
   "Chat_SuggestionB": "חקור נושא",
   "Chat_SuggestionC": "צור מסמך",
   "Chat_AvatarLetter": "ל",
+  "Chat_EditPlaceholder": "ערוך את ההודעה...",
+  "Chat_EditStatus": "עריכת הודעה - אפשר לשנות טקסט, קבצים מצורפים, סוכן, מודל או MCPs ואז לשלוח.",
 
   "Editor_Lumi": "עורך לומי",
   "Editor_Project": "עורך פרויקט",

--- a/src/Lumi/Services/DataStore.cs
+++ b/src/Lumi/Services/DataStore.cs
@@ -256,6 +256,12 @@ public class DataStore
                 ToolOutput = m.ToolOutput,
                 IsStreaming = m.IsStreaming,
                 Model = m.Model,
+                ReasoningEffort = m.ReasoningEffort,
+                AgentId = m.AgentId,
+                SdkAgentName = m.SdkAgentName,
+                HasAgentSelection = m.HasAgentSelection,
+                ActiveMcpServerNames = [..m.ActiveMcpServerNames],
+                HasMcpSelection = m.HasMcpSelection,
                 Attachments = [..m.Attachments],
                 ActiveSkills = [..m.ActiveSkills.Select(static s => new SkillReference
                 {

--- a/src/Lumi/ViewModels/ChatViewModel.cs
+++ b/src/Lumi/ViewModels/ChatViewModel.cs
@@ -137,6 +137,20 @@ public partial class ChatViewModel : ObservableObject
     /// <summary>Tracks the last assistant message ID that already produced suggestions per chat.</summary>
     private readonly Dictionary<Guid, Guid> _lastSuggestedAssistantMessageByChat = new();
 
+    private sealed record ComposerEditSnapshot(
+        string PromptText,
+        List<string> PendingAttachments,
+        List<Guid> ActiveSkillIds,
+        List<string> ActiveExternalSkillNames,
+        Guid? AgentId,
+        string? SdkAgentName,
+        string? SelectedModel,
+        string? SelectedReasoningEffort,
+        List<string> ActiveMcpServerNames);
+
+    private ComposerEditSnapshot? _preEditComposerSnapshot;
+    private ChatMessage? _editingUserMessage;
+
     /// <summary>Gets or lazily creates a per-chat BrowserService instance.</summary>
     private BrowserService GetOrCreateBrowserService(Guid chatId)
     {
@@ -173,6 +187,9 @@ public partial class ChatViewModel : ObservableObject
     [ObservableProperty] private bool _isStreaming;
     [ObservableProperty] private string _statusText = "";
     [ObservableProperty] private string? _selectedModel;
+    [ObservableProperty] private bool _isEditingMessage;
+    [ObservableProperty] private string _editingMessageStatusText = "";
+    public string ComposerPlaceholder => IsEditingMessage ? Loc.Get("Chat_EditPlaceholder") : Loc.Chat_Placeholder;
 
     partial void OnIsBusyChanging(bool value)
     {
@@ -380,6 +397,7 @@ public partial class ChatViewModel : ObservableObject
             dataStore,
             showDiffAction: item => DiffShowRequested?.Invoke(item),
             submitQuestionAnswerAction: SubmitQuestionAnswer,
+            beginEditMessageAction: BeginComposerEdit,
             resendFromMessageAction: ResendFromMessageAsync,
             getSelectedModel: () => SelectedModel);
         _transcriptBuilder.SetLiveTarget(_transcriptTurns);
@@ -455,6 +473,11 @@ public partial class ChatViewModel : ObservableObject
             if (IsCodingProject)
                 _ = RefreshCodingProjectState();
         }
+    }
+
+    partial void OnIsEditingMessageChanged(bool value)
+    {
+        OnPropertyChanged(nameof(ComposerPlaceholder));
     }
 
     partial void OnStatusTextChanged(string value)
@@ -906,6 +929,8 @@ public partial class ChatViewModel : ObservableObject
         if (CurrentChat?.Id != chat.Id)
         {
             _suggestionDisplayChatId = chat.Id;
+            if (IsEditingMessage)
+                CancelComposerEditInternal(restoreComposer: true, focusComposer: false);
 
             // Save unsent composer draft for the chat we're leaving
             var leavingId = CurrentChat?.Id ?? Guid.Empty;
@@ -1148,6 +1173,9 @@ public partial class ChatViewModel : ObservableObject
             try { _chatLoadCts?.Cancel(); }
             catch (ObjectDisposedException) { }
         }
+
+        if (IsEditingMessage)
+            CancelComposerEditInternal(restoreComposer: true, focusComposer: false);
 
         // Save unsent composer draft for the chat we're leaving
         var leavingId = CurrentChat?.Id ?? Guid.Empty;
@@ -1504,9 +1532,339 @@ public partial class ChatViewModel : ObservableObject
         return builder.ToString();
     }
 
+    private void BeginComposerEdit(ChatMessage userMessage)
+    {
+        if (CurrentChat is null || userMessage.Role != "user")
+            return;
+
+        if (_editingUserMessage?.Id == userMessage.Id && IsEditingMessage)
+        {
+            FocusComposerRequested?.Invoke();
+            return;
+        }
+
+        if (_editingUserMessage is not null && _editingUserMessage.Id != userMessage.Id)
+            CancelComposerEditInternal(restoreComposer: true, focusComposer: false);
+
+        _preEditComposerSnapshot ??= CaptureComposerEditSnapshot();
+        _editingUserMessage = userMessage;
+        IsEditingMessage = true;
+        EditingMessageStatusText = Loc.Get("Chat_EditStatus");
+        ClearSuggestions();
+
+        PromptText = userMessage.Content;
+        ReplacePendingAttachments(userMessage.Attachments);
+        ReplaceActiveSkillsFromMessage(userMessage);
+        ApplyMessageAgentSelection(userMessage);
+        ApplyMessageModelSelection(userMessage);
+        ApplyMessageMcpSelection(userMessage);
+
+        FocusComposerRequested?.Invoke();
+    }
+
+    private ComposerEditSnapshot CaptureComposerEditSnapshot()
+        => new(
+            PromptText ?? string.Empty,
+            PendingAttachments.ToList(),
+            ActiveSkillIds.ToList(),
+            _activeExternalSkillNames.ToList(),
+            ActiveAgent?.Id,
+            SelectedSdkAgentName,
+            SelectedModel,
+            GetSelectedReasoningEffort(),
+            ActiveMcpServerNames.ToList());
+
+    private void RestoreComposerEditSnapshot(ComposerEditSnapshot snapshot)
+    {
+        PromptText = snapshot.PromptText;
+        ReplacePendingAttachments(snapshot.PendingAttachments);
+        ReplaceActiveSkills(snapshot.ActiveSkillIds, snapshot.ActiveExternalSkillNames, syncToChat: true);
+        ApplyAgentSelection(snapshot.AgentId, snapshot.SdkAgentName);
+        ApplyModelSelection(snapshot.SelectedModel, snapshot.SelectedReasoningEffort);
+        ReplaceActiveMcpSelection(snapshot.ActiveMcpServerNames, syncToChat: true);
+    }
+
+    [RelayCommand]
+    private void CancelComposerEdit()
+        => CancelComposerEditInternal(restoreComposer: true, focusComposer: true);
+
+    private void CancelComposerEditInternal(bool restoreComposer, bool focusComposer)
+    {
+        var snapshot = _preEditComposerSnapshot;
+        _editingUserMessage = null;
+        _preEditComposerSnapshot = null;
+        IsEditingMessage = false;
+        EditingMessageStatusText = string.Empty;
+
+        if (restoreComposer && snapshot is not null)
+            RestoreComposerEditSnapshot(snapshot);
+
+        if (focusComposer)
+            FocusComposerRequested?.Invoke();
+    }
+
+    private async Task SendEditedMessage()
+    {
+        if (CurrentChat is null || _editingUserMessage is not { } userMessage)
+            return;
+
+        if (string.IsNullOrWhiteSpace(PromptText))
+            return;
+
+        var prompt = PromptText.Trim();
+        var selectedReasoningEffort = GetPersistedReasoningEffortPreference();
+        var attachments = TakePendingAttachments() ?? [];
+
+        userMessage.Content = prompt;
+        userMessage.Attachments = attachments
+            .OfType<UserMessageAttachmentFile>()
+            .Select(static attachment => attachment.Path)
+            .ToList();
+        ApplyCurrentComposerSelectionsToMessage(userMessage, selectedReasoningEffort);
+        ApplyCurrentComposerSelectionsToChat(CurrentChat, selectedReasoningEffort);
+
+        _editingUserMessage = null;
+        _preEditComposerSnapshot = null;
+        IsEditingMessage = false;
+        EditingMessageStatusText = string.Empty;
+        PromptText = string.Empty;
+        _chatDrafts.Remove(CurrentChat.Id);
+
+        await ResendFromMessageAsync(userMessage, wasEdited: true, attachments);
+    }
+
+    private void ReplacePendingAttachments(IEnumerable<string> paths)
+    {
+        PendingAttachments.Clear();
+        PendingAttachmentItems.Clear();
+
+        foreach (var path in paths.Where(static p => !string.IsNullOrWhiteSpace(p)).Distinct(StringComparer.OrdinalIgnoreCase))
+            AddAttachment(path);
+    }
+
+    private void ReplaceActiveSkillsFromMessage(ChatMessage message)
+    {
+        var (skillIds, externalSkillNames) = ResolveSkillSelectionsFromReferences(message.ActiveSkills);
+        ReplaceActiveSkills(skillIds, externalSkillNames, syncToChat: true);
+    }
+
+    private (List<Guid> SkillIds, List<string> ExternalSkillNames) ResolveSkillSelectionsFromReferences(
+        IEnumerable<SkillReference> skillReferences)
+    {
+        var skillIds = new List<Guid>();
+        var externalSkillNames = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var skillRef in skillReferences)
+        {
+            if (string.IsNullOrWhiteSpace(skillRef.Name) || !seen.Add(skillRef.Name))
+                continue;
+
+            var skill = FindSkillByName(skillRef.Name);
+            if (skill is not null)
+                skillIds.Add(skill.Id);
+            else
+                externalSkillNames.Add(skillRef.Name);
+        }
+
+        return (skillIds, externalSkillNames);
+    }
+
+    private void ReplaceActiveSkills(
+        IEnumerable<Guid> skillIds,
+        IEnumerable<string> externalSkillNames,
+        bool syncToChat)
+    {
+        ActiveSkillIds.Clear();
+        ActiveSkillChips.Clear();
+        _activeExternalSkillNames.Clear();
+
+        foreach (var skillId in skillIds.Distinct())
+        {
+            var skill = _dataStore.Data.Skills.FirstOrDefault(s => s.Id == skillId);
+            if (skill is null)
+                continue;
+
+            ActiveSkillIds.Add(skill.Id);
+            ActiveSkillChips.Add(new StrataComposerChip(skill.Name, skill.IconGlyph));
+        }
+
+        foreach (var name in externalSkillNames.Where(static n => !string.IsNullOrWhiteSpace(n)).Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            _activeExternalSkillNames.Add(name);
+            var reference = FindSkillReferenceByName(name);
+            ActiveSkillChips.Add(new StrataComposerChip(reference?.Name ?? name, reference?.Glyph ?? ExternalSkillGlyph));
+        }
+
+        if (syncToChat)
+            SyncActiveSkillsToChat();
+    }
+
+    private void ApplyMessageAgentSelection(ChatMessage message)
+    {
+        if (!message.HasAgentSelection)
+            return;
+
+        ApplyAgentSelection(message.AgentId, message.SdkAgentName);
+    }
+
+    private void ApplyAgentSelection(Guid? agentId, string? sdkAgentName)
+    {
+        if (agentId.HasValue)
+        {
+            var agent = _dataStore.Data.Agents.FirstOrDefault(a => a.Id == agentId.Value);
+            if (agent is not null)
+            {
+                SelectedSdkAgentName = null;
+                SetActiveAgent(agent);
+                return;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(sdkAgentName))
+        {
+            SetActiveAgent(null);
+            SelectedSdkAgentName = sdkAgentName;
+            return;
+        }
+
+        SelectedSdkAgentName = null;
+        SetActiveAgent(null);
+    }
+
+    private void ApplyMessageModelSelection(ChatMessage message)
+    {
+        var model = !string.IsNullOrWhiteSpace(message.Model)
+            ? message.Model
+            : ResolveModelForMessageEdit(message);
+
+        ApplyModelSelection(model, message.ReasoningEffort ?? CurrentChat?.LastReasoningEffortUsed);
+    }
+
+    private string? ResolveModelForMessageEdit(ChatMessage message)
+    {
+        if (CurrentChat is not { } chat)
+            return SelectedModel;
+
+        var index = chat.Messages.IndexOf(message);
+        if (index >= 0)
+        {
+            for (var i = index + 1; i < chat.Messages.Count; i++)
+            {
+                var next = chat.Messages[i];
+                if (next.Role == "user")
+                    break;
+
+                if (next.Role == "assistant" && !string.IsNullOrWhiteSpace(next.Model))
+                    return next.Model;
+            }
+        }
+
+        return chat.LastModelUsed ?? SelectedModel ?? _dataStore.Data.Settings.PreferredModel;
+    }
+
+    private void ApplyMessageMcpSelection(ChatMessage message)
+    {
+        if (!message.HasMcpSelection)
+            return;
+
+        ReplaceActiveMcpSelection(message.ActiveMcpServerNames, syncToChat: true);
+    }
+
+    private void ReplaceActiveMcpSelection(IEnumerable<string> serverNames, bool syncToChat)
+    {
+        _suppressActiveMcpCollectionSync = true;
+        try
+        {
+            ActiveMcpServerNames.Clear();
+            ActiveMcpChips.Clear();
+
+            foreach (var name in serverNames.Where(static n => !string.IsNullOrWhiteSpace(n)).Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                ActiveMcpServerNames.Add(name);
+                ActiveMcpChips.Add(CreateMcpChip(name));
+            }
+        }
+        finally
+        {
+            _suppressActiveMcpCollectionSync = false;
+        }
+
+        if (syncToChat)
+            SyncActiveMcpsToChat();
+    }
+
+    private StrataComposerChip CreateMcpChip(string name)
+        => AvailableMcpChips
+            .OfType<StrataComposerChip>()
+            .FirstOrDefault(chip => chip.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+           ?? new StrataComposerChip(name);
+
+    private void ApplyCurrentComposerSelectionsToMessage(ChatMessage message, string? selectedReasoningEffort)
+    {
+        message.Model = SelectedModel;
+        message.ReasoningEffort = selectedReasoningEffort;
+        message.AgentId = ActiveAgent?.Id;
+        message.SdkAgentName = SelectedSdkAgentName;
+        message.HasAgentSelection = true;
+        message.ActiveMcpServerNames = new List<string>(ActiveMcpServerNames);
+        message.HasMcpSelection = true;
+        message.ActiveSkills = BuildSkillReferences(ActiveSkillIds, _activeExternalSkillNames);
+    }
+
+    private void ApplyCurrentComposerSelectionsToChat(Chat chat, string? selectedReasoningEffort)
+    {
+        chat.AgentId = ActiveAgent?.Id;
+        chat.SdkAgentName = SelectedSdkAgentName;
+        chat.ActiveSkillIds = new List<Guid>(ActiveSkillIds);
+        chat.ActiveExternalSkillNames = new List<string>(_activeExternalSkillNames);
+        chat.ActiveMcpServerNames = new List<string>(ActiveMcpServerNames);
+        chat.LastModelUsed = SelectedModel;
+        chat.LastReasoningEffortUsed = selectedReasoningEffort;
+        QueueSaveChat(chat, saveIndex: true);
+    }
+
+    private void ApplyMessageSelectionsToChat(Chat chat, ChatMessage message, string? selectedReasoningEffort)
+    {
+        if (message.HasAgentSelection)
+        {
+            chat.AgentId = message.AgentId;
+            chat.SdkAgentName = message.SdkAgentName;
+        }
+
+        var (skillIds, externalSkillNames) = ResolveSkillSelectionsFromReferences(message.ActiveSkills);
+        chat.ActiveSkillIds = skillIds;
+        chat.ActiveExternalSkillNames = externalSkillNames;
+
+        if (message.HasMcpSelection)
+            chat.ActiveMcpServerNames = new List<string>(message.ActiveMcpServerNames);
+
+        if (!string.IsNullOrWhiteSpace(message.Model))
+            chat.LastModelUsed = message.Model;
+        chat.LastReasoningEffortUsed = selectedReasoningEffort;
+        QueueSaveChat(chat, saveIndex: true);
+    }
+
+    private static List<UserMessageAttachment> BuildUserMessageAttachments(IEnumerable<string> attachmentPaths)
+        => attachmentPaths
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(static path => (UserMessageAttachment)new UserMessageAttachmentFile
+            {
+                Path = path,
+                DisplayName = Path.GetFileName(path)
+            })
+            .ToList();
+
     [RelayCommand]
     private async Task SendMessage()
     {
+        if (_editingUserMessage is not null)
+        {
+            await SendEditedMessage();
+            return;
+        }
+
         await SendMessageCore(PromptText, consumeComposerPrompt: true);
     }
 
@@ -1603,6 +1961,13 @@ public partial class ChatViewModel : ObservableObject
                 Role = "user",
                 Content = prompt,
                 Author = _dataStore.Data.Settings.UserName ?? Loc.Author_You,
+                Model = SelectedModel,
+                ReasoningEffort = selectedReasoningEffort,
+                AgentId = ActiveAgent?.Id,
+                SdkAgentName = SelectedSdkAgentName,
+                HasAgentSelection = true,
+                ActiveMcpServerNames = new List<string>(ActiveMcpServerNames),
+                HasMcpSelection = true,
                 Attachments = attachments?.OfType<UserMessageAttachmentFile>().Select(a => a.Path).ToList() ?? [],
                 ActiveSkills = BuildSkillReferences(ActiveSkillIds, _activeExternalSkillNames)
             };
@@ -3099,6 +3464,12 @@ public partial class ChatViewModel : ObservableObject
     /// The message content may have been edited before calling this.
     /// </summary>
     public async Task ResendFromMessageAsync(ChatMessage userMessage, bool wasEdited)
+        => await ResendFromMessageAsync(userMessage, wasEdited, attachmentsOverride: null);
+
+    private async Task ResendFromMessageAsync(
+        ChatMessage userMessage,
+        bool wasEdited,
+        List<UserMessageAttachment>? attachmentsOverride)
     {
         if (CurrentChat is null) return;
 
@@ -3110,6 +3481,9 @@ public partial class ChatViewModel : ObservableObject
         if (idx < 0) return;
 
         var prompt = userMessage.Content;
+        var attachments = attachmentsOverride ?? BuildUserMessageAttachments(userMessage.Attachments);
+        var selectedReasoningEffort = userMessage.ReasoningEffort ?? GetPersistedReasoningEffortPreference();
+        ApplyMessageSelectionsToChat(CurrentChat, userMessage, selectedReasoningEffort);
 
         // Remove the user message and everything after it
         while (CurrentChat.Messages.Count > idx)
@@ -3143,7 +3517,23 @@ public partial class ChatViewModel : ObservableObject
         {
             Role = "user",
             Content = prompt,
-            Author = userMessage.Author
+            Author = userMessage.Author,
+            Model = userMessage.Model,
+            ReasoningEffort = userMessage.ReasoningEffort,
+            AgentId = userMessage.AgentId,
+            SdkAgentName = userMessage.SdkAgentName,
+            HasAgentSelection = userMessage.HasAgentSelection,
+            ActiveMcpServerNames = new List<string>(userMessage.ActiveMcpServerNames),
+            HasMcpSelection = userMessage.HasMcpSelection,
+            Attachments = userMessage.Attachments.ToList(),
+            ActiveSkills = userMessage.ActiveSkills
+                .Select(static skill => new SkillReference
+                {
+                    Name = skill.Name,
+                    Glyph = skill.Glyph,
+                    Description = skill.Description
+                })
+                .ToList()
         };
         CurrentChat.Messages.Add(newUserMsg);
         Messages.Add(new ChatMessageViewModel(newUserMsg));
@@ -3174,7 +3564,10 @@ public partial class ChatViewModel : ObservableObject
         }
 
         MessageOptions? resendOptions = null;
-        var promptAdditions = BuildSendPromptAdditions();
+        var (_, resendExternalSkillNames) = ResolveSkillSelectionsFromReferences(userMessage.ActiveSkills);
+        var promptAdditions = BuildSendPromptAdditions(
+            resendExternalSkillNames,
+            consumePendingSkillInjections: false);
         var localUserMessageCount = 0;
         var localAssistantMessageCount = 0;
         try
@@ -3247,6 +3640,12 @@ public partial class ChatViewModel : ObservableObject
             IsStreaming = runtime.IsStreaming;
             StatusText = runtime.StatusText;
 
+            if (WorktreePath is { Length: > 0 } wtPath && attachments.Count > 0)
+            {
+                var projDir = GetProjectWorkingDirectory();
+                RebaseAttachmentPaths(attachments, newUserMsg, projDir, wtPath);
+            }
+
             var resendPrompt = BuildResendPrompt(
                 retainedContext,
                 prompt,
@@ -3255,6 +3654,9 @@ public partial class ChatViewModel : ObservableObject
                 promptAdditions);
 
             resendOptions = new MessageOptions { Prompt = resendPrompt };
+            if (attachments.Count > 0)
+                resendOptions.Attachments = attachments;
+
             localUserMessageCount = CurrentChat.Messages.Count(m => m.Role == "user");
             localAssistantMessageCount = CountCompletedAssistantMessages(CurrentChat);
             var expectedSessionUserMessageCount = await CaptureExpectedSessionUserMessageCountAsync(
@@ -3293,6 +3695,9 @@ public partial class ChatViewModel : ObservableObject
                     shouldReplayPrompt: !wasEdited,
                     promptAdditions);
                 resendOptions = new MessageOptions { Prompt = resendPrompt2 };
+                if (attachments.Count > 0)
+                    resendOptions.Attachments = attachments;
+
                 var expectedSessionUserMessageCount = await CaptureExpectedSessionUserMessageCountAsync(
                     _activeSession!,
                     localUserMessageCount,

--- a/src/Lumi/ViewModels/TranscriptBuilder.cs
+++ b/src/Lumi/ViewModels/TranscriptBuilder.cs
@@ -18,6 +18,7 @@ public class TranscriptBuilder
     private readonly DataStore _dataStore;
     private readonly Action<FileChangeItem> _showDiffAction;
     private readonly Action<string, string> _submitQuestionAnswerAction;
+    private readonly Action<ChatMessage> _beginEditMessageAction;
     private readonly Func<ChatMessage, bool, Task> _resendFromMessageAction;
     private readonly Func<string?> _getSelectedModel;
 
@@ -67,12 +68,14 @@ public class TranscriptBuilder
         DataStore dataStore,
         Action<FileChangeItem> showDiffAction,
         Action<string, string> submitQuestionAnswerAction,
+        Action<ChatMessage> beginEditMessageAction,
         Func<ChatMessage, bool, Task> resendFromMessageAction,
         Func<string?> getSelectedModel)
     {
         _dataStore = dataStore;
         _showDiffAction = showDiffAction;
         _submitQuestionAnswerAction = submitQuestionAnswerAction;
+        _beginEditMessageAction = beginEditMessageAction;
         _resendFromMessageAction = resendFromMessageAction;
         _getSelectedModel = getSelectedModel;
     }
@@ -850,7 +853,12 @@ public class TranscriptBuilder
             var newSkills = msgVm.Message.ActiveSkills
                 .Where(s => _shownSkillNames.Add(s.Name))
                 .ToList();
-            var userItem = new UserMessageItem(msgVm, showTimestamps, newSkills, (msg, edited) => _ = _resendFromMessageAction(msg, edited));
+            var userItem = new UserMessageItem(
+                msgVm,
+                showTimestamps,
+                newSkills,
+                msg => _beginEditMessageAction(msg),
+                (msg, edited) => _ = _resendFromMessageAction(msg, edited));
             AppendToCurrentTurn(userItem, TurnStableIdFor($"message:{msgVm.Message.Id}"));
             FinalizeCurrentTurn();
             return;

--- a/src/Lumi/ViewModels/TranscriptItems.cs
+++ b/src/Lumi/ViewModels/TranscriptItems.cs
@@ -50,6 +50,7 @@ public abstract partial class TranscriptItem : ObservableObject
 public partial class UserMessageItem : TranscriptItem
 {
     private readonly ChatMessageViewModel _source;
+    private readonly Action<ChatMessage>? _beginEditAction;
     private readonly Action<ChatMessage, bool>? _resendAction;
 
     [ObservableProperty] private string _content;
@@ -73,17 +74,23 @@ public partial class UserMessageItem : TranscriptItem
     /// <summary>Command invoked when user clicks Regenerate/Retry on the message.</summary>
     public ICommand ResendCommand { get; }
 
-    public UserMessageItem(ChatMessageViewModel source, bool showTimestamps, List<SkillReference>? filteredSkills = null, Action<ChatMessage, bool>? resendAction = null)
+    public UserMessageItem(
+        ChatMessageViewModel source,
+        bool showTimestamps,
+        List<SkillReference>? filteredSkills = null,
+        Action<ChatMessage>? beginEditAction = null,
+        Action<ChatMessage, bool>? resendAction = null)
         : base($"message:user:{source.Message.Id}")
     {
         _source = source;
+        _beginEditAction = beginEditAction;
         _resendAction = resendAction;
         _content = source.Content;
         _timestampText = showTimestamps ? source.TimestampText : "";
         Attachments = source.Message.Attachments.Select(fp => new FileAttachmentItem(fp)).ToList();
         Skills = filteredSkills ?? source.Message.ActiveSkills.ToList();
 
-        BeginEditCommand = new RelayCommand(() => { /* Strata handles entering edit mode internally */ });
+        BeginEditCommand = new RelayCommand(() => _beginEditAction?.Invoke(_source.Message));
         ConfirmEditCommand = new RelayCommand<string>(text => EditAndResend(text ?? Content));
         ResendCommand = new RelayCommand(ResendFromMessage);
     }

--- a/src/Lumi/ViewModels/UiThrottler.cs
+++ b/src/Lumi/ViewModels/UiThrottler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Threading;
@@ -102,13 +103,15 @@ internal sealed class UiThrottler(Action action, TimeSpan minimumInterval, Dispa
         {
             // Token was cancelled — the caller has already scheduled a replacement.
         }
-        catch
+        catch (Exception ex)
         {
             // Unexpected error — reset _scheduled so future requests aren't permanently blocked.
             lock (_gate)
             {
                 _scheduled = false;
             }
+
+            Trace.TraceError("UiThrottler scheduling failed: {0}", ex);
         }
     }
 
@@ -125,6 +128,13 @@ internal sealed class UiThrottler(Action action, TimeSpan minimumInterval, Dispa
             _lastRunUtc = DateTime.UtcNow;
         }
 
-        _action();
+        try
+        {
+            _action();
+        }
+        catch (Exception ex)
+        {
+            Trace.TraceError("UiThrottler action failed: {0}", ex);
+        }
     }
 }

--- a/src/Lumi/Views/ChatView.axaml
+++ b/src/Lumi/Views/ChatView.axaml
@@ -412,6 +412,7 @@
                             Author="{Binding Author}"
                             Timestamp="{Binding TimestampText}"
                             IsEditable="True"
+                            UseInlineEdit="False"
                             EditText="{Binding Content, Mode=OneWay}"
                             EditCommand="{Binding BeginEditCommand}"
                             EditConfirmedCommand="{Binding ConfirmEditCommand}"
@@ -1447,8 +1448,43 @@
         </Grid>
       </Border>
 
+      <Border IsVisible="{Binding IsEditingMessage}"
+              Margin="4,0,4,0"
+              Padding="10,7"
+              CornerRadius="10"
+              Background="{DynamicResource Brush.AccentSubtle}"
+              BorderBrush="{DynamicResource Brush.AccentDefault}"
+              BorderThickness="1">
+        <Grid ColumnDefinitions="*,Auto">
+          <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="7">
+            <PathIcon Width="12"
+                      Height="12"
+                      VerticalAlignment="Center"
+                      Foreground="{DynamicResource Brush.AccentDefault}"
+                      Data="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a1.003 1.003 0 0 0 0-1.42l-2.34-2.34a1.003 1.003 0 0 0-1.42 0l-1.83 1.83 3.75 3.75 1.84-1.82z" />
+            <TextBlock Text="{Binding EditingMessageStatusText}"
+                       FontSize="12"
+                       FontWeight="SemiBold"
+                       Foreground="{DynamicResource Brush.AccentDefault}"
+                       VerticalAlignment="Center"
+                       TextWrapping="Wrap" />
+          </StackPanel>
+          <Button Grid.Column="1"
+                  Content="{loc:Str Common_Cancel}"
+                  Classes="subtle"
+                  Command="{Binding CancelComposerEditCommand}"
+                  Padding="8,3"
+                  MinHeight="0"
+                  CornerRadius="6"
+                  FontSize="12"
+                  FontWeight="SemiBold"
+                  Foreground="{DynamicResource Brush.AccentDefault}"
+                  Cursor="Hand" />
+        </Grid>
+      </Border>
+
       <sc:StrataChatComposer x:Name="Composer"
-                             Placeholder="{loc:Str Chat_Placeholder}"
+                             Placeholder="{Binding ComposerPlaceholder}"
                              PromptText="{Binding PromptText, Mode=TwoWay}"
                              IsBusy="{Binding IsBusy}"
                              IsRecording="{Binding IsRecording}"

--- a/tests/Lumi.Tests/BackgroundResumeTests.cs
+++ b/tests/Lumi.Tests/BackgroundResumeTests.cs
@@ -133,7 +133,7 @@ public sealed class BackgroundResumeTests
     // ── Helpers ──
 
     private static TranscriptBuilder CreateBuilder()
-        => new(CreateDataStore(), _ => { }, (_, _) => { }, (_, _) => Task.CompletedTask, () => null);
+        => new(CreateDataStore(), _ => { }, (_, _) => { }, _ => { }, (_, _) => Task.CompletedTask, () => null);
 
     private static ChatMessageViewModel CreateToolVm(
         string toolCallId,

--- a/tests/Lumi.Tests/ChatViewModelEditTests.cs
+++ b/tests/Lumi.Tests/ChatViewModelEditTests.cs
@@ -1,0 +1,204 @@
+using System.Reflection;
+using Lumi.Models;
+using Lumi.Services;
+using Lumi.ViewModels;
+using Xunit;
+
+namespace Lumi.Tests;
+
+public sealed class ChatViewModelEditTests
+{
+    [Fact]
+    public void BeginComposerEdit_LoadsMessageAttachmentsAndTurnSelectionsIntoComposer()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"lumi-edit-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        var messageAttachment = Path.Combine(tempRoot, "message-attachment.txt");
+        File.WriteAllText(messageAttachment, "message attachment");
+
+        try
+        {
+            var skill = new Skill
+            {
+                Id = Guid.NewGuid(),
+                Name = "Review skill",
+                IconGlyph = "R"
+            };
+            var agent = new LumiAgent
+            {
+                Id = Guid.NewGuid(),
+                Name = "Review Agent",
+                IconGlyph = "A"
+            };
+            var activeMcp = new McpServer { Name = "docs", IsEnabled = true };
+            var inactiveForMessageMcp = new McpServer { Name = "calendar", IsEnabled = true };
+            var message = new ChatMessage
+            {
+                Role = "user",
+                Content = "Original message",
+                Model = "claude-sonnet-4.6",
+                ReasoningEffort = "high",
+                AgentId = agent.Id,
+                HasAgentSelection = true,
+                ActiveMcpServerNames = [activeMcp.Name],
+                HasMcpSelection = true,
+                Attachments = [messageAttachment],
+                ActiveSkills =
+                [
+                    new SkillReference
+                    {
+                        Name = skill.Name,
+                        Glyph = skill.IconGlyph,
+                        Description = skill.Description
+                    }
+                ]
+            };
+            var chat = new Chat
+            {
+                Id = Guid.NewGuid(),
+                Title = "Edit test",
+                Messages = [message],
+                ActiveMcpServerNames = [inactiveForMessageMcp.Name],
+                LastModelUsed = "gpt-5-mini"
+            };
+            var appData = new AppData
+            {
+                Settings = new UserSettings { PreferredModel = "gpt-5-mini" },
+                Chats = [chat],
+                Skills = [skill],
+                Agents = [agent],
+                McpServers = [activeMcp, inactiveForMessageMcp]
+            };
+            var viewModel = new ChatViewModel(new DataStore(appData), new CopilotService())
+            {
+                CurrentChat = chat,
+                PromptText = "Draft before editing"
+            };
+
+            InvokeBeginComposerEdit(viewModel, message);
+
+            Assert.True(viewModel.IsEditingMessage);
+            Assert.Equal("Original message", viewModel.PromptText);
+            Assert.Equal(messageAttachment, Assert.Single(viewModel.PendingAttachments));
+            Assert.Same(agent, viewModel.ActiveAgent);
+            Assert.Equal(agent.Name, viewModel.SelectedAgentName);
+            Assert.Equal("claude-sonnet-4.6", viewModel.SelectedModel);
+            Assert.Equal(skill.Id, Assert.Single(viewModel.ActiveSkillIds));
+            Assert.Equal(activeMcp.Name, Assert.Single(viewModel.ActiveMcpServerNames));
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void BeginComposerEdit_WithExplicitEmptyAgentAndMcpSelectionsClearsComposerChips()
+    {
+        var agent = new LumiAgent
+        {
+            Id = Guid.NewGuid(),
+            Name = "Draft Agent"
+        };
+        var mcp = new McpServer { Name = "docs", IsEnabled = true };
+        var message = new ChatMessage
+        {
+            Role = "user",
+            Content = "Original message",
+            HasAgentSelection = true,
+            HasMcpSelection = true
+        };
+        var chat = new Chat
+        {
+            Id = Guid.NewGuid(),
+            Title = "Edit test",
+            AgentId = agent.Id,
+            ActiveMcpServerNames = [mcp.Name],
+            Messages = [message]
+        };
+        var appData = new AppData
+        {
+            Chats = [chat],
+            Agents = [agent],
+            McpServers = [mcp]
+        };
+        var viewModel = new ChatViewModel(new DataStore(appData), new CopilotService())
+        {
+            CurrentChat = chat
+        };
+        viewModel.SetActiveAgent(agent);
+        viewModel.AddMcpServer(mcp.Name);
+
+        InvokeBeginComposerEdit(viewModel, message);
+
+        Assert.Null(viewModel.ActiveAgent);
+        Assert.Null(viewModel.SelectedSdkAgentName);
+        Assert.Null(viewModel.SelectedAgentName);
+        Assert.Empty(viewModel.ActiveMcpServerNames);
+        Assert.Empty(viewModel.ActiveMcpChips);
+    }
+
+    [Fact]
+    public void SwitchingEditedMessageRestoresOriginalComposerSnapshotOnCancel()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"lumi-edit-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        var draftAttachment = Path.Combine(tempRoot, "draft.txt");
+        var firstMessageAttachment = Path.Combine(tempRoot, "first-message.txt");
+        File.WriteAllText(draftAttachment, "draft attachment");
+        File.WriteAllText(firstMessageAttachment, "first message attachment");
+
+        try
+        {
+            var firstMessage = new ChatMessage
+            {
+                Role = "user",
+                Content = "First message",
+                Attachments = [firstMessageAttachment]
+            };
+            var secondMessage = new ChatMessage
+            {
+                Role = "user",
+                Content = "Second message"
+            };
+            var chat = new Chat
+            {
+                Id = Guid.NewGuid(),
+                Title = "Edit test",
+                Messages = [firstMessage, secondMessage]
+            };
+            var viewModel = new ChatViewModel(new DataStore(new AppData { Chats = [chat] }), new CopilotService())
+            {
+                CurrentChat = chat,
+                PromptText = "Draft before editing"
+            };
+            viewModel.AddAttachment(draftAttachment);
+
+            InvokeBeginComposerEdit(viewModel, firstMessage);
+            viewModel.PromptText = "Unsaved first edit";
+
+            InvokeBeginComposerEdit(viewModel, secondMessage);
+            viewModel.CancelComposerEditCommand.Execute(null);
+
+            Assert.Equal("Draft before editing", viewModel.PromptText);
+            var attachment = Assert.Single(viewModel.PendingAttachments);
+            Assert.Equal(draftAttachment, attachment);
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    private static void InvokeBeginComposerEdit(ChatViewModel viewModel, ChatMessage message)
+    {
+        var method = typeof(ChatViewModel).GetMethod(
+            "BeginComposerEdit",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.NotNull(method);
+        method!.Invoke(viewModel, [message]);
+    }
+}

--- a/tests/Lumi.Tests/TranscriptBuilderSubagentTests.cs
+++ b/tests/Lumi.Tests/TranscriptBuilderSubagentTests.cs
@@ -78,7 +78,7 @@ public sealed class TranscriptBuilderSubagentTests
     }
 
     private static TranscriptBuilder CreateBuilder()
-        => new(CreateDataStore(), _ => { }, (_, _) => { }, (_, _) => Task.CompletedTask, () => null);
+        => new(CreateDataStore(), _ => { }, (_, _) => { }, _ => { }, (_, _) => Task.CompletedTask, () => null);
 
     private static ChatMessageViewModel CreateToolVm(
         string toolCallId,

--- a/tests/Lumi.Tests/TranscriptBuilderToolGroupTests.cs
+++ b/tests/Lumi.Tests/TranscriptBuilderToolGroupTests.cs
@@ -609,7 +609,7 @@ public sealed class TranscriptBuilderToolGroupTests
     }
 
     private static TranscriptBuilder CreateBuilder(bool showToolCalls = true)
-        => new(CreateDataStore(showToolCalls), _ => { }, (_, _) => { }, (_, _) => Task.CompletedTask, () => null);
+        => new(CreateDataStore(showToolCalls), _ => { }, (_, _) => { }, _ => { }, (_, _) => Task.CompletedTask, () => null);
 
     private static void AssertCompactFinishedToolGroup(TranscriptItem item, int expectedToolCalls)
     {


### PR DESCRIPTION
## Summary
- Rework user-message editing to open the normal chat composer instead of the inline text-only editor.
- Preserve existing attachments and allow attachment add/remove while editing.
- Preserve and edit per-message agent, model, skill, and MCP selections before resending.
- Persist per-message composition metadata and migrate existing saved data safely.
- Update the Strata submodule to use the host-owned edit hook from adirh3/Strata#2.
- Add focused regression coverage for edit-mode state restoration and explicit no-agent/no-MCP selections.

## Validation
- `dotnet build src\Lumi\Lumi.csproj` with the local .NET 11 SDK.
- Targeted Lumi edit + throttler regression tests passed.
- Targeted Strata `UseInlineEdit=false` regression test passed.
- `git diff --check` passed.
- Avalonia MCP live UI check passed with no binding errors.

Note: full Lumi and Strata suite runs hung at the runner/build layer without emitting test failures, so this PR is validated with the targeted regression suites plus live MCP UI verification.